### PR TITLE
Fixed DescribeConfigsResponse_v0 and v1.

### DIFF
--- a/library/kafka_lib.py
+++ b/library/kafka_lib.py
@@ -229,7 +229,7 @@ class DescribeConfigsResponse_v0(Response):
             ('resource_type', Int8),
             ('resource_name', String('utf-8')),
             ('config_entries', Array(
-                ('config_names', String('utf-8')),
+                ('config_name', String('utf-8')),
                 ('config_value', String('utf-8')),
                 ('read_only', Boolean),
                 ('is_default', Boolean),
@@ -247,10 +247,10 @@ class DescribeConfigsResponse_v1(Response):
             ('resource_type', Int8),
             ('resource_name', String('utf-8')),
             ('config_entries', Array(
-                ('config_names', String('utf-8')),
+                ('config_name', String('utf-8')),
                 ('config_value', String('utf-8')),
                 ('read_only', Boolean),
-                ('is_default', Boolean),
+                ('config_source', Int8),
                 ('is_sensitive', Boolean),
                 ('config_synonyms', Array(
                     ('config_name', String('utf-8')),


### PR DESCRIPTION
Due to [KIP-226](https://cwiki.apache.org/confluence/display/KAFKA/KIP-226+-+Dynamic+Broker+Configuration) boolean ``is_default`` has been replaced with the more generic ``config_source`` in ``DescribeConfigsResponse_v1``.

Moreover a typo has been fixed (``config_names`` instead of ``config_name``) in ``DescribeConfigsResponse_v0`` as well as ``DescribeConfigsResponse_v1``.
