### PR TITLE
Fix typo "cluster_action" vs. "cluster_actions"

### DIFF
--- a/library/kafka_lib.py
+++ b/library/kafka_lib.py
@@ -110,7 +110,7 @@ options:
   acl_operation:
     description:
       - 'the operation the ACL controls.'
-    choices: [all, alter, alter_configs, cluster_actions, create, delete,
+    choices: [all, alter, alter_configs, cluster_action, create, delete,
                 describe, describe_configs, idempotent_write, read, write]
   acl_pattern_type:
     description:
@@ -1528,7 +1528,7 @@ def main():
             acl_principal=dict(type='str', required=False),
 
             acl_operation=dict(choices=['all', 'alter', 'alter_configs',
-                                        'cluster_actions', 'create', 'delete',
+                                        'cluster_action', 'create', 'delete',
                                         'describe', 'describe_configs',
                                         'idempotent_write', 'read', 'write'],
                                required=False),


### PR DESCRIPTION
This fixes a typo in the singular vs. plural form of the ACL operation "cluster_action".

The Kafka operation is called "CLUSTER_ACTION", which is also what the ACL operation code always expected. But the input validation code would only accept the plural form, so this could not work.