### PR TITLE
Ensure the partition reassignment is finished after updating the number of replica

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ script:
   - molecule prepare --force
   - molecule converge -- --tags test_partitions
   - molecule prepare --force
+  - molecule converge -- --tags test_partitions_and_replica_factor
+  - molecule prepare --force
   - molecule converge -- --tags test_options
   - molecule prepare --force
   - molecule converge -- --tags test_delete

--- a/README.md
+++ b/README.md
@@ -53,6 +53,21 @@ Here some examples on how to use this library:
     zookeeper: "{{ hostvars['zookeeper']['ansible_eth0']['ipv4']['address'] }}:2181"
     bootstrap_servers: "{{ hostvars['kafka1']['ansible_eth0']['ipv4']['address'] }}:9092,{{ hostvars['kafka2']['ansible_eth0']['ipv4']['address'] }}:9092"
 
+# from previous topic, update the number of partitions and the number of replicas. Be aware that this action can take some times to happen on Kafka
+# so be sure to set the `zookeeper_max_retries` and `zookeeper_sleep_time` parameters to avoid hitting the timeout.
+- name: update topic
+  kafka_lib:
+    resource: "topic"
+    api_version: "1.0.1"
+    name: "test"
+    partitions: 4
+    replica_factor: 2
+    options:
+      retention.ms: 574930
+    state: "present"
+    zookeeper: "{{ hostvars['zookeeper']['ansible_eth0']['ipv4']['address'] }}:2181"
+    bootstrap_servers: "{{ hostvars['kafka1']['ansible_eth0']['ipv4']['address'] }}:9092,{{ hostvars['kafka2']['ansible_eth0']['ipv4']['address'] }}:9092"
+
 # creates a topic for a sasl_ssl configured Kafka and plaintext Zookeeper
 - name: create topic
   kafka_lib:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -53,6 +53,28 @@
             seconds: 10
       tags: test_partitions
 
+    - name: update partitions and replica factor
+      block:
+        - name: set fact for current test
+          set_fact:
+            topic_defaut_configuration: "{{ topic_defaut_configuration | combine({ 'partitions': 4, 'replica_factor': 2 }) }}"
+            cacheable: "yes"
+        - name: update partitions and replica factor
+          kafka_lib:
+            resource: 'topic'
+            api_version: "{{ item.protocol_version }}"
+            name: "{{ topic_name }}"
+            partitions: "{{ topic_defaut_configuration.partitions }}"
+            replica_factor: "{{ topic_defaut_configuration.replica_factor }}"
+            state: "{{  topic_defaut_configuration.state }}"
+            zookeeper: "{{ hostvars['zookeeper-' + item.instance_suffix]['ansible_eth0']['ipv4']['address'] }}:2181"
+            bootstrap_servers: "{{ bootstrap_plain }}"
+          with_items: "{{ ansible_kafka_supported_versions }}"
+        - name: wait for partition & replica update completion
+          pause:
+            seconds: 10
+      tags: test_partitions_and_replica_factor
+
     - name: add options
       block:
         - name: set fact for current test


### PR DESCRIPTION
Ensure the partition reassignment is finished (thus the znode is missing) after updating the number of replica.

Fixes https://github.com/StephenSorriaux/ansible-kafka-admin/issues/46

## Proposed Changes

  - Add a new method to ensure the znode is missing before AND after updating the number of replica for a topic.
  - Add a new method to refresh topics state after an action was done.
  - Add an example (and a warning) in the README.md file.
  - Add a test to verify the behaviour.