### PR TITLE
Fix lag calculation + add option to ignore empty partition when calculating lag

### DIFF
--- a/module_utils/kafka_consumer_lag.py
+++ b/module_utils/kafka_consumer_lag.py
@@ -15,6 +15,8 @@ _GroupCoordinatorResponse = GroupCoordinatorResponse_v0
 # Time value '-1' is to get the offset for next new message (=> last offset)
 LATEST_TIMESTAMP = -1
 
+EARLIEST_TIMESTAMP = -2
+
 AS_CONSUMER = -1
 
 
@@ -36,7 +38,8 @@ class KafkaConsumerLag:
         else:
             raise f.exception()
 
-    def get_lag_stats(self, consumer_group=None):
+    def get_lag_stats(self, consumer_group=None,
+                      ignore_empty_partition=False):
         cluster = self.client.cluster
         brokers = cluster.brokers()
 
@@ -75,14 +78,12 @@ class KafkaConsumerLag:
                  _OffsetFetchResponse)
 
         for topic, partitions in response.topics:
-            current_offsets[topic] = []
+            current_offsets[topic] = {}
             if topic not in topics:
                 topics.append(topic)
             for partition in partitions:
                 partition_index, commited_offset, _, _ = partition
-                current_offsets.setdefault(topic, []).append(
-                    (partition_index, commited_offset)
-                )
+                current_offsets[topic][partition_index] = commited_offset
 
         # Get last offset for each topic partition coordinated by each broker
         # Result object is set up also
@@ -91,26 +92,48 @@ class KafkaConsumerLag:
             topics_partitions_by_broker = filter_by_topic(
                                 cluster.partitions_for_broker(broker.nodeId),
                                 topics)
-            request_topic_partitions = build_offset_request_topics_partitions(
-                                           topics_partitions_by_broker)
+            request_latest_topic_partitions = \
+                build_offset_request_topics_partitions(
+                    topics_partitions_by_broker, LATEST_TIMESTAMP)
+            request_earliest_topic_partitions = \
+                build_offset_request_topics_partitions(
+                    topics_partitions_by_broker, EARLIEST_TIMESTAMP)
 
-            response = self._send(
+            response_latest = self._send(
                      broker.nodeId,
-                     _OffsetRequest(AS_CONSUMER, request_topic_partitions),
+                     _OffsetRequest(AS_CONSUMER,
+                                    request_latest_topic_partitions),
+                     _OffsetResponse)
+            response_earliest = self._send(
+                     broker.nodeId,
+                     _OffsetRequest(AS_CONSUMER,
+                                    request_earliest_topic_partitions),
                      _OffsetResponse)
 
-            for topic, partitions in response.topics:
+            earliest_offsets = {}
+            for topic, partitions in response_earliest.topics:
+                earliest_offsets[topic] = {}
+                for partition in partitions:
+                    partition_id, _, _, offset = partition
+                    earliest_offsets[topic][partition_id] = offset
+
+            for topic, partitions in response_latest.topics:
                 for partition in partitions:
                     partition_id, _, _, last_offset = partition
-                    current_offset = current_offsets[topic][partition_id][1]
-                    lag = last_offset - current_offset
-                    global_lag += lag
-                    # Set up result object
-                    results.setdefault(topic, {})[partition_id] = {
-                        'current_offset': current_offset,
-                        'last_offset': last_offset,
-                        'lag': last_offset - current_offset
-                    }
+                    # Ignore empty partition for lag count
+                    if ignore_empty_partition and \
+                       earliest_offsets[topic][partition_id] == last_offset:
+                        continue
+                    if partition_id in current_offsets[topic]:
+                        current_offset = current_offsets[topic][partition_id]
+                        lag = last_offset - current_offset
+                        global_lag += lag
+                        # Set up result object
+                        results.setdefault(topic, {})[partition_id] = {
+                            'current_offset': current_offset,
+                            'last_offset': last_offset,
+                            'lag': last_offset - current_offset
+                        }
 
         results["global_lag_count"] = global_lag
         return results
@@ -120,11 +143,11 @@ def filter_by_topic(topics_partitions, topics):
     return [tp for tp in topics_partitions if tp.topic in topics]
 
 
-def build_offset_request_topics_partitions(topics_partitions):
+def build_offset_request_topics_partitions(topics_partitions, timestamp):
     _topics_partitions = {}
     for topic, partition in topics_partitions:
         _topics_partitions.setdefault(topic, []).append(
-            (partition, LATEST_TIMESTAMP)
+            (partition, timestamp)
         )
     # convert to array for _OffsetRequest Struct
     return list(_topics_partitions.items())


### PR DESCRIPTION
Fix lag calculation + add option to ignore empty partition when calculating lag

## Fixes
Use à `dict` to calculate lag <=> consumer may not commit offset on empty partitions

## Proposed Changes

  - Add option to ignore empty partitions to calculate lag
