### PR TITLE
Use DeleteAclRequest_v1 if broker version is over 2.0.0

### DIFF
--- a/library/kafka_lib.py
+++ b/library/kafka_lib.py
@@ -813,7 +813,7 @@ def main():
         elif state == 'absent':
             if acl_resource_found:
                 if not module.check_mode:
-                    manager.delete_acls([acl_resource])
+                    manager.delete_acls([acl_resource], api_version)
                 changed = True
                 msg += 'successfully deleted.'
 

--- a/module_utils/kafka_manager.py
+++ b/module_utils/kafka_manager.py
@@ -12,6 +12,7 @@ from kafka.protocol.admin import (
     CreateAclsRequest_v0,
     CreateAclsRequest_v1,
     DeleteAclsRequest_v0,
+    DeleteAclsRequest_v1,
     DescribeAclsRequest_v0,
     DescribeAclsRequest_v1)
 
@@ -290,6 +291,18 @@ class KafkaManager:
             acl_resource.permission_type
         )
 
+    @staticmethod
+    def _convert_delete_acls_resource_request_v1(acl_resource):
+        return (
+            acl_resource.resource_type,
+            acl_resource.name,
+            acl_resource.pattern_type,
+            acl_resource.principal,
+            acl_resource.host,
+            acl_resource.operation,
+            acl_resource.permission_type
+        )
+
     def describe_acls(self, acl_resource, api_version):
         """Describe a set of ACLs
         """
@@ -353,13 +366,19 @@ class KafkaManager:
                     )
                 )
 
-    def delete_acls(self, acl_resources):
+    def delete_acls(self, acl_resources, api_version):
         """Delete a set of ACLSs"""
 
-        request = DeleteAclsRequest_v0(
-            filters=[self._convert_delete_acls_resource_request_v0(
-                acl_resource) for acl_resource in acl_resources]
-        )
+        if api_version < parse_version('2.0.0'):
+            request = DeleteAclsRequest_v0(
+                filters=[self._convert_delete_acls_resource_request_v0(
+                    acl_resource) for acl_resource in acl_resources]
+            )
+        else:
+            request = DeleteAclsRequest_v1(
+                filters=[self._convert_delete_acls_resource_request_v1(
+                    acl_resource) for acl_resource in acl_resources]
+            )
 
         response = self.send_request_and_get_response(request)
 


### PR DESCRIPTION
Fixes https://github.com/StephenSorriaux/ansible-kafka-admin/issues/61

## Proposed Changes

  - Use DeleteAclRequest_v1 if broker version is over 2.0.0
  - (also forced EOL to LF, that's why the huge diff)