### PR TITLE
Make the lib compatible with kafka-python >= 1.4.5

### DIFF
--- a/module_utils/kafka_consumer_lag.py
+++ b/module_utils/kafka_consumer_lag.py
@@ -25,7 +25,6 @@ class KafkaConsumerLag:
     def __init__(self, kafka_client):
 
         self.client = kafka_client
-        self.client.check_version()
 
     def _send(self, broker_id, request, response_type=None):
 
@@ -62,6 +61,7 @@ class KafkaConsumerLag:
         for broker in brokers:
             while not self.client.is_ready(broker.nodeId):
                 self.client.ready(broker.nodeId)
+                self.client.poll()
 
         # Identify which broker is coordinating this consumer group
         response = self._send(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-kafka-python==1.4.4
+kafka-python>=1.4.5,<2.1.0
 kazoo==2.6.1
 pure-sasl==0.5.1


### PR DESCRIPTION
Fixes https://github.com/StephenSorriaux/ansible-kafka-admin/issues/33

## Proposed Changes

  - use `client_async` module instead of `client`
  - use `poll()` to create connection to brokers if needed, since it is not done at `KafkaClient()` init anymore
  - `refresh()` at manager init
  - consider the fact that the `CreateTopicsResponse_v0` object changed
  - update `requirements.txt` with versions of `kafka-python` that should work
  - some fixes on tests

Hopefully, this will add the compatibility with Python 3.7+
