### PR TITLE
Disable zookeeper when possible. Now only needed when replication factor must be changed with kafka < 2.4.0 or kafka <= 0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add the following requirement in your playbook's **requirements.yml**:
 ## Usage
 ### Creating, updating, deleting topics and ACLs
 **Note**
-* Zookeeper is only needed when replication-factor changed or kafka <= 0.11.0.
+* Zookeeper is only needed when replication-factor changed wiht Kafka < 2.4.0 or with Kafka <= 0.11.0.
 
 Here some examples on how to use this library:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Add the following requirement in your playbook's **requirements.yml**:
 ## Usage
 ### Creating, updating, deleting topics and ACLs
 **Note**
-* Zookeeper is only needed when replication-factor changed wiht Kafka < 2.4.0 or with Kafka <= 0.11.0.
+Zookeeper is only needed when:
+* replication-factor changed with Kafka < 2.4.0
+* Kafka <= 0.11.0
 
 Here some examples on how to use this library:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Add the following requirement in your playbook's **requirements.yml**:
 ```
 ## Usage
 ### Creating, updating, deleting topics and ACLs
+**Note**
+* Zookeeper is only needed when replication-factor changed or kafka <= 0.11.0.
+
 Here some examples on how to use this library:
 ```yaml
 # creates a topic 'test' with provided configuation for plaintext configured Kafka and Zookeeper

--- a/library/kafka_lib.py
+++ b/library/kafka_lib.py
@@ -140,6 +140,17 @@ options:
       - 'when updating number of partitions and while checking for'
       - 'the ZK node, maximum of try to do before failing'
       default: 5
+  kafka_sleep_time:
+    description:
+      - 'when updating number of partitions and while checking for'
+      - 'kafka to applied, the time to sleep (in seconds) between'
+      - 'each checks.'
+      default: 5
+  kafka_max_retries:
+    description:
+      - 'when updating number of partitions and while checking for'
+      - 'kafka to applied, maximum of try to do before failing'
+      default: 5
 ''' + DOCUMENTATION_COMMON
 
 EXAMPLES = '''

--- a/library/kafka_topic.py
+++ b/library/kafka_topic.py
@@ -104,6 +104,17 @@ options:
       - 'when updating number of partitions and while checking for'
       - 'the ZK node, maximum of try to do before failing'
       default: 5
+  kafka_sleep_time:
+    description:
+      - 'when updating number of partitions and while checking for'
+      - 'kafka to applied, the time to sleep (in seconds) between'
+      - 'each checks.'
+      default: 5
+  kafka_max_retries:
+    description:
+      - 'when updating number of partitions and while checking for'
+      - 'kafka to applied, maximum of try to do before failing'
+      default: 5
 ''' + DOCUMENTATION_COMMON
 
 EXAMPLES = '''

--- a/module_utils/kafka_lib_commons.py
+++ b/module_utils/kafka_lib_commons.py
@@ -253,6 +253,10 @@ def get_manager_from_params(params):
             'Current version of library is not compatible with '
             'Kafka < 0.11.0.'
         )
+    if 'zookeeper' in params:
+        manager.zookeeper_sleep_time = params['zookeeper_sleep_time']
+        manager.zookeeper_max_retries = params['zookeeper_max_retries']
+        manager.zk_configuration = get_zookeeper_configuration(params)
 
     return manager
 
@@ -278,38 +282,40 @@ def maybe_clean_kafka_ssl_files(params):
 
 def get_zookeeper_configuration(params):
     zookeeper = params['zookeeper']
-    zookeeper_auth_scheme = params['zookeeper_auth_scheme']
-    zookeeper_auth_value = params['zookeeper_auth_value']
-    zookeeper_ssl_check_hostname = params['zookeeper_ssl_check_hostname']
-    zookeeper_ssl_cafile = params['zookeeper_ssl_cafile']
-    zookeeper_ssl_certfile = params['zookeeper_ssl_certfile']
-    zookeeper_ssl_keyfile = params['zookeeper_ssl_keyfile']
-    zookeeper_ssl_password = params['zookeeper_ssl_password']
+    if zookeeper is not None:
+        zookeeper_auth_scheme = params['zookeeper_auth_scheme']
+        zookeeper_auth_value = params['zookeeper_auth_value']
+        zookeeper_ssl_check_hostname = params['zookeeper_ssl_check_hostname']
+        zookeeper_ssl_cafile = params['zookeeper_ssl_cafile']
+        zookeeper_ssl_certfile = params['zookeeper_ssl_certfile']
+        zookeeper_ssl_keyfile = params['zookeeper_ssl_keyfile']
+        zookeeper_ssl_password = params['zookeeper_ssl_password']
 
-    zookeeper_ssl_files = generate_ssl_object(
-      zookeeper_ssl_cafile, zookeeper_ssl_certfile,
-      zookeeper_ssl_keyfile
-    )
-    zookeeper_use_ssl = bool(
-        zookeeper_ssl_files['keyfile']['path'] is not None and
-        zookeeper_ssl_files['certfile']['path'] is not None
-    )
+        zookeeper_ssl_files = generate_ssl_object(
+          zookeeper_ssl_cafile, zookeeper_ssl_certfile,
+          zookeeper_ssl_keyfile
+        )
+        zookeeper_use_ssl = bool(
+            zookeeper_ssl_files['keyfile']['path'] is not None and
+            zookeeper_ssl_files['certfile']['path'] is not None
+        )
 
-    zookeeper_auth = []
-    if zookeeper_auth_value != '':
-        auth = (zookeeper_auth_scheme, zookeeper_auth_value)
-        zookeeper_auth.append(auth)
+        zookeeper_auth = []
+        if zookeeper_auth_value != '':
+            auth = (zookeeper_auth_scheme, zookeeper_auth_value)
+            zookeeper_auth.append(auth)
 
-    return dict(
-        hosts=zookeeper,
-        auth_data=zookeeper_auth,
-        keyfile=zookeeper_ssl_files['keyfile']['path'],
-        use_ssl=zookeeper_use_ssl,
-        keyfile_password=zookeeper_ssl_password,
-        certfile=zookeeper_ssl_files['certfile']['path'],
-        ca=zookeeper_ssl_files['cafile']['path'],
-        verify_certs=zookeeper_ssl_check_hostname
-    )
+        return dict(
+            hosts=zookeeper,
+            auth_data=zookeeper_auth,
+            keyfile=zookeeper_ssl_files['keyfile']['path'],
+            use_ssl=zookeeper_use_ssl,
+            keyfile_password=zookeeper_ssl_password,
+            certfile=zookeeper_ssl_files['certfile']['path'],
+            ca=zookeeper_ssl_files['cafile']['path'],
+            verify_certs=zookeeper_ssl_check_hostname
+        )
+    return None
 
 
 def maybe_clean_zk_ssl_files(params):

--- a/module_utils/kafka_lib_commons.py
+++ b/module_utils/kafka_lib_commons.py
@@ -73,6 +73,10 @@ module_topic_commons = dict(
     replica_factor=dict(type='int', required=False, default=0),
 
     options=dict(required=False, type='dict', default=None),
+
+    kafka_sleep_time=dict(type='int', required=False, default=5),
+
+    kafka_max_retries=dict(type='int', required=False, default=5),
 )
 
 module_acl_commons = dict(
@@ -253,10 +257,18 @@ def get_manager_from_params(params):
             'Current version of library is not compatible with '
             'Kafka < 0.11.0.'
         )
+
+    if 'kafka_sleep_time' in params:
+        manager.kafka_sleep_time = params['kafka_sleep_time']
+    if 'kafka_max_retries' in params:
+        manager.kafka_max_retries = params['kafka_max_retries']
+
     if 'zookeeper' in params:
-        manager.zookeeper_sleep_time = params['zookeeper_sleep_time']
-        manager.zookeeper_max_retries = params['zookeeper_max_retries']
         manager.zk_configuration = get_zookeeper_configuration(params)
+    if 'zookeeper_sleep_time' in params:
+        manager.zookeeper_sleep_time = params['zookeeper_sleep_time']
+    if 'zookeeper_max_retries' in params:
+        manager.zookeeper_max_retries = params['zookeeper_max_retries']
 
     return manager
 

--- a/module_utils/kafka_lib_topic.py
+++ b/module_utils/kafka_lib_topic.py
@@ -62,7 +62,6 @@ def process_module_topic(module):
         )
     except Exception:
         e = get_exception()
-        raise e
         module.fail_json(
             msg='Something went wrong: %s' % e
         )

--- a/module_utils/kafka_lib_topic.py
+++ b/module_utils/kafka_lib_topic.py
@@ -5,7 +5,7 @@ from ansible.module_utils.pycompat24 import get_exception
 
 from ansible.module_utils.kafka_lib_commons import (
     get_manager_from_params,
-    maybe_clean_kafka_ssl_files, get_zookeeper_configuration,
+    maybe_clean_kafka_ssl_files,
     maybe_clean_zk_ssl_files
 )
 
@@ -17,14 +17,10 @@ def process_module_topic(module):
     partitions = params['partitions']
     replica_factor = params['replica_factor']
     state = params['state']
-    zookeeper_sleep_time = params['zookeeper_sleep_time']
-    zookeeper_max_retries = params['zookeeper_max_retries']
 
     options = []
     if params['options'] is not None:
         options = params['options'].items()
-
-    zk_configuration = get_zookeeper_configuration(params)
 
     changed = False
     msg = 'topic \'%s\': ' % (name)
@@ -37,9 +33,8 @@ def process_module_topic(module):
             if name in manager.get_topics():
                 if not module.check_mode:
                     changed, warn = manager.ensure_topic(
-                        name, zk_configuration, options, partitions,
-                        replica_factor, zookeeper_sleep_time,
-                        zookeeper_max_retries
+                        name, options, partitions,
+                        replica_factor
                     )
                     if changed:
                         msg += 'successfully updated.'
@@ -67,6 +62,7 @@ def process_module_topic(module):
         )
     except Exception:
         e = get_exception()
+        raise e
         module.fail_json(
             msg='Something went wrong: %s' % e
         )

--- a/module_utils/kafka_protocol.py
+++ b/module_utils/kafka_protocol.py
@@ -1,3 +1,48 @@
+from kafka.protocol.api import Request, Response, RequestHeader
+from kafka.protocol.struct import Struct
+from kafka.protocol.types import (Boolean,
+                                  Int8,
+                                  Int16,
+                                  Int32, String, Schema, Array)
+
+
+# Bug https://github.com/dpkp/kafka-python/pull/2206
+class DescribeConfigsResponse_v1(Response):
+    API_KEY = 32
+    API_VERSION = 1
+    SCHEMA = Schema(
+        ('throttle_time_ms', Int32),
+        ('resources', Array(
+            ('error_code', Int16),
+            ('error_message', String('utf-8')),
+            ('resource_type', Int8),
+            ('resource_name', String('utf-8')),
+            ('config_entries', Array(
+                ('config_names', String('utf-8')),
+                ('config_value', String('utf-8')),
+                ('read_only', Boolean),
+                ('config_source', Int8),
+                ('is_sensitive', Boolean),
+                ('config_synonyms', Array(
+                    ('config_name', String('utf-8')),
+                    ('config_value', String('utf-8')),
+                    ('config_source', Int8)))))))
+    )
+
+
+class DescribeConfigsRequest_v1(Request):
+    API_KEY = 32
+    API_VERSION = 1
+    RESPONSE_TYPE = DescribeConfigsResponse_v1
+    SCHEMA = Schema(
+        ('resources', Array(
+            ('resource_type', Int8),
+            ('resource_name', String('utf-8')),
+            ('config_names', Array(String('utf-8'))))),
+        ('include_synonyms', Boolean)
+    )
+
+
 try:
     from kafka.protocol.admin import AlterPartitionReassignmentsRequest_v0 \
         as _AlterPartitionReassignmentsRequest_v0
@@ -14,9 +59,6 @@ except Exception:
     import kafka.errors as Errors
     from kafka.protocol.commit import GroupCoordinatorResponse
     from kafka.protocol.parser import KafkaProtocol, log
-    from kafka.protocol.api import Request, Response, RequestHeader
-    from kafka.protocol.struct import Struct
-    from kafka.protocol.types import Int16, Int32, String, Schema, Array
     from kafka.protocol import API_KEYS
 
     # TODO use AlterPartitionReassignmentsRequest_v0 when

--- a/module_utils/kafka_protocol.py
+++ b/module_utils/kafka_protocol.py
@@ -1,0 +1,368 @@
+try:
+    from kafka.protocol.admin import AlterPartitionReassignmentsRequest_v0 \
+        as _AlterPartitionReassignmentsRequest_v0
+    from kafka.protocol.admin import ListPartitionReassignmentsRequest_v0 \
+        as _ListPartitionReassignmentsRequest_v0
+    ListPartitionReassignmentsRequest_v0 = \
+        _ListPartitionReassignmentsRequest_v0
+    AlterPartitionReassignmentsRequest_v0 = \
+        _AlterPartitionReassignmentsRequest_v0
+except Exception:
+    import struct
+    from kafka.protocol.abstract import AbstractType
+
+    import kafka.errors as Errors
+    from kafka.protocol.commit import GroupCoordinatorResponse
+    from kafka.protocol.parser import KafkaProtocol, log
+    from kafka.protocol.api import Request, Response, RequestHeader
+    from kafka.protocol.struct import Struct
+    from kafka.protocol.types import Int16, Int32, String, Schema, Array
+    from kafka.protocol import API_KEYS
+
+    # TODO use AlterPartitionReassignmentsRequest_v0 when
+    # https://github.com/dpkp/kafka-python/commit/9feeb79140ed10e3a7f2036491fc07573740c231
+    # will be released
+
+    Request.FLEXIBLE_VERSION = False
+
+    def default_build_request_header(self, correlation_id, client_id):
+        if self.FLEXIBLE_VERSION:
+            return RequestHeaderV2(self,
+                                   correlation_id=correlation_id,
+                                   client_id=client_id)
+        return RequestHeader(self,
+                             correlation_id=correlation_id,
+                             client_id=client_id)
+
+    def default_parse_response_header(self, read_buffer):
+        if self.FLEXIBLE_VERSION:
+            return ResponseHeaderV2.decode(read_buffer)
+        return ResponseHeader.decode(read_buffer)
+
+    Request.build_request_header = default_build_request_header
+    Request.parse_response_header = default_parse_response_header
+
+    def send_request(self, request, correlation_id=None):
+        """Encode and queue a kafka api request for sending.
+        Arguments:
+           request (object): An un-encoded kafka request.
+           correlation_id (int, optional): Optionally specify an ID to
+               correlate requests with responses. If not provided, an ID will
+               be generated automatically.
+        Returns:
+           correlation_id
+        """
+        log.debug('Sending request %s', request)
+        if correlation_id is None:
+            correlation_id = self._next_correlation_id()
+
+        header = request.build_request_header(
+            correlation_id=correlation_id, client_id=self._client_id)
+        message = b''.join([header.encode(), request.encode()])
+        size = Int32.encode(len(message))
+        data = size + message
+        self.bytes_to_send.append(data)
+        if request.expect_response():
+            ifr = (correlation_id, request)
+            self.in_flight_requests.append(ifr)
+        return correlation_id
+
+    def _process_response(self, read_buffer):
+        if not self.in_flight_requests:
+            raise Errors.CorrelationIdError(
+                'No in-flight-request found for server response')
+        (correlation_id, request) = self.in_flight_requests.popleft()
+        response_header = request.parse_response_header(read_buffer)
+        recv_correlation_id = response_header.correlation_id
+        log.debug('Received correlation id: %d', recv_correlation_id)
+        # 0.8.2 quirk
+        if (recv_correlation_id == 0 and
+            correlation_id != 0 and
+            request.RESPONSE_TYPE is GroupCoordinatorResponse[0] and
+                (self._api_version == (0, 8, 2) or self._api_version is None)):
+            log.warning('Kafka 0.8.2 quirk -- GroupCoordinatorResponse'
+                        ' Correlation ID does not match request. This'
+                        ' should go away once at least one topic has been'
+                        ' initialized on the broker.')
+
+        elif correlation_id != recv_correlation_id:
+            # return or raise?
+            raise Errors.CorrelationIdError(
+                'Correlation IDs do not match: sent %d, recv %d'
+                % (correlation_id, recv_correlation_id))
+
+        # decode response
+        log.debug('Processing response %s', request.RESPONSE_TYPE.__name__)
+        try:
+            response = request.RESPONSE_TYPE.decode(read_buffer)
+        except ValueError:
+            read_buffer.seek(0)
+            buf = read_buffer.read()
+            log.error('Response %d [ResponseType: %s Request: %s]:'
+                      ' Unable to decode %d-byte buffer: %r',
+                      correlation_id, request.RESPONSE_TYPE,
+                      request, len(buf), buf)
+            raise Errors.KafkaProtocolError('Unable to decode response')
+
+        return (correlation_id, response)
+
+    KafkaProtocol.send_request = send_request
+    KafkaProtocol._process_response = _process_response
+
+    class UnsignedVarInt32(AbstractType):
+        @classmethod
+        def decode(cls, data):
+            value, i = 0, 0
+            while True:
+                b, = struct.unpack('B', data.read(1))
+                if not (b & 0x80):
+                    break
+                value |= (b & 0x7f) << i
+                i += 7
+                if i > 28:
+                    raise ValueError('Invalid value {}'.format(value))
+            value |= b << i
+            return value
+
+        @classmethod
+        def encode(cls, value):
+            value &= 0xffffffff
+            ret = b''
+            while (value & 0xffffff80) != 0:
+                b = (value & 0x7f) | 0x80
+                ret += struct.pack('B', b)
+                value >>= 7
+            ret += struct.pack('B', value)
+            return ret
+
+    class VarInt32(AbstractType):
+        @classmethod
+        def decode(cls, data):
+            value = UnsignedVarInt32.decode(data)
+            return (value >> 1) ^ -(value & 1)
+
+        @classmethod
+        def encode(cls, value):
+            # bring it in line with the java binary repr
+            value &= 0xffffffff
+            return UnsignedVarInt32.encode((value << 1) ^ (value >> 31))
+
+    class VarInt64(AbstractType):
+        @classmethod
+        def decode(cls, data):
+            value, i = 0, 0
+            while True:
+                b = data.read(1)
+                if not (b & 0x80):
+                    break
+                value |= (b & 0x7f) << i
+                i += 7
+                if i > 63:
+                    raise ValueError('Invalid value {}'.format(value))
+            value |= b << i
+            return (value >> 1) ^ -(value & 1)
+
+        @classmethod
+        def encode(cls, value):
+            # bring it in line with the java binary repr
+            value &= 0xffffffffffffffff
+            v = (value << 1) ^ (value >> 63)
+            ret = b''
+            while (v & 0xffffffffffffff80) != 0:
+                b = (value & 0x7f) | 0x80
+                ret += struct.pack('B', b)
+                v >>= 7
+            ret += struct.pack('B', v)
+            return ret
+
+    class CompactString(String):
+        def decode(self, data):
+            length = UnsignedVarInt32.decode(data) - 1
+            if length < 0:
+                return None
+            value = data.read(length)
+            if len(value) != length:
+                raise ValueError('Buffer underrun decoding string')
+            return value.decode(self.encoding)
+
+        def encode(self, value):
+            if value is None:
+                return UnsignedVarInt32.encode(0)
+            value = str(value).encode(self.encoding)
+            return UnsignedVarInt32.encode(len(value) + 1) + value
+
+    class TaggedFields(AbstractType):
+        @classmethod
+        def decode(cls, data):
+            num_fields = UnsignedVarInt32.decode(data)
+            ret = {}
+            if not num_fields:
+                return ret
+            prev_tag = -1
+            for i in range(num_fields):
+                tag = UnsignedVarInt32.decode(data)
+                if tag <= prev_tag:
+                    raise ValueError('Invalid or out-of-order tag {}'
+                                     .format(tag))
+                prev_tag = tag
+                size = UnsignedVarInt32.decode(data)
+                val = data.read(size)
+                ret[tag] = val
+            return ret
+
+        @classmethod
+        def encode(cls, value):
+            ret = UnsignedVarInt32.encode(len(value))
+            for k, v in value.items():
+                # do we allow for other data types ??
+                # It could get complicated really fast
+                assert isinstance(v, bytes), \
+                    'Value {} is not a byte array'.format(v)
+                assert isinstance(k, int) and k > 0, \
+                    'Key {} is not a positive integer'.format(k)
+                ret += UnsignedVarInt32.encode(k)
+                ret += v
+            return ret
+
+    class CompactBytes(AbstractType):
+        @classmethod
+        def decode(cls, data):
+            length = UnsignedVarInt32.decode(data) - 1
+            if length < 0:
+                return None
+            value = data.read(length)
+            if len(value) != length:
+                raise ValueError('Buffer underrun decoding Bytes')
+            return value
+
+        @classmethod
+        def encode(cls, value):
+            if value is None:
+                return UnsignedVarInt32.encode(0)
+            else:
+                return UnsignedVarInt32.encode(len(value) + 1) + value
+
+    class CompactArray(Array):
+
+        def encode(self, items):
+            if items is None:
+                return UnsignedVarInt32.encode(0)
+            return b''.join(
+                [UnsignedVarInt32.encode(len(items) + 1)] +
+                [self.array_of.encode(item) for item in items]
+            )
+
+        def decode(self, data):
+            length = UnsignedVarInt32.decode(data) - 1
+            if length == -1:
+                return None
+            return [self.array_of.decode(data) for _ in range(length)]
+
+    class RequestHeaderV2(Struct):
+        # Flexible response / request headers end in field buffer
+        SCHEMA = Schema(
+            ('api_key', Int16),
+            ('api_version', Int16),
+            ('correlation_id', Int32),
+            ('client_id', String('utf-8')),
+            ('tags', TaggedFields),
+        )
+
+        def __init__(self, request, correlation_id=0,
+                     client_id='kafka-python', tags=None):
+            super(RequestHeaderV2, self).__init__(
+                request.API_KEY,
+                request.API_VERSION,
+                correlation_id,
+                client_id,
+                tags or {}
+            )
+
+    class ResponseHeader(Struct):
+        SCHEMA = Schema(
+            ('correlation_id', Int32),
+        )
+
+    class ResponseHeaderV2(Struct):
+        SCHEMA = Schema(
+            ('correlation_id', Int32),
+            ('tags', TaggedFields),
+        )
+
+    class AlterPartitionReassignmentsResponse_v0(Response):
+        API_KEY = 45
+        API_VERSION = 0
+        SCHEMA = Schema(
+            ("throttle_time_ms", Int32),
+            ("error_code", Int16),
+            ("error_message", CompactString("utf-8")),
+            ("responses", CompactArray(
+                ("name", CompactString("utf-8")),
+                ("partitions", CompactArray(
+                    ("partition_index", Int32),
+                    ("error_code", Int16),
+                    ("error_message", CompactString("utf-8")),
+                    ("tags", TaggedFields)
+                )),
+                ("tags", TaggedFields)
+            )),
+            ("tags", TaggedFields)
+        )
+
+    class AlterPartitionReassignmentsRequest_v0(Request):
+        FLEXIBLE_VERSION = True
+        API_KEY = 45
+        API_VERSION = 0
+        RESPONSE_TYPE = AlterPartitionReassignmentsResponse_v0
+        SCHEMA = Schema(
+            ("timeout_ms", Int32),
+            ("topics", CompactArray(
+                ("name", CompactString("utf-8")),
+                ("partitions", CompactArray(
+                    ("partition_index", Int32),
+                    ("replicas", CompactArray(Int32)),
+                    ("tags", TaggedFields)
+                )),
+                ("tags", TaggedFields)
+            )),
+            ("tags", TaggedFields)
+        )
+
+    class ListPartitionReassignmentsResponse_v0(Response):
+        API_KEY = 46
+        API_VERSION = 0
+        SCHEMA = Schema(
+            ("throttle_time_ms", Int32),
+            ("error_code", Int16),
+            ("error_message", CompactString("utf-8")),
+            ("topics", CompactArray(
+                ("name", CompactString("utf-8")),
+                ("partitions", CompactArray(
+                    ("partition_index", Int32),
+                    ("replicas", CompactArray(Int32)),
+                    ("adding_replicas", CompactArray(Int32)),
+                    ("removing_replicas", CompactArray(Int32)),
+                    ("tags", TaggedFields)
+                )),
+                ("tags", TaggedFields)
+            )),
+            ("tags", TaggedFields)
+        )
+
+    class ListPartitionReassignmentsRequest_v0(Request):
+        FLEXIBLE_VERSION = True
+        API_KEY = 46
+        API_VERSION = 0
+        RESPONSE_TYPE = ListPartitionReassignmentsResponse_v0
+        SCHEMA = Schema(
+            ("timeout_ms", Int32),
+            ("topics", CompactArray(
+                ("name", CompactString("utf-8")),
+                ("partition_index", CompactArray(Int32)),
+                ("tags", TaggedFields)
+            )),
+            ("tags", TaggedFields)
+        )
+
+    API_KEYS[45] = 'AlterPartitionReassignments'
+    API_KEYS[46] = 'ListPartitionReassignments'

--- a/molecule/default/tests/ansible_utils.py
+++ b/molecule/default/tests/ansible_utils.py
@@ -4,6 +4,7 @@ import json
 import six
 import testinfra
 
+from pkg_resources import parse_version
 from datetime import datetime
 
 from tests.utils import KafkaManager
@@ -61,6 +62,8 @@ sasl_default_configuration = {
 env_no_sasl = []
 env_sasl = []
 
+host_protocol_version = {}
+
 ansible_kafka_supported_versions = \
     (molecule_configuration['provisioner']
      ['inventory']
@@ -84,6 +87,7 @@ for supported_version in ansible_kafka_supported_versions:
     )
     kfk1_addr = (kfk1.ansible.get_variables()['ansible_eth0']
                  ['ipv4']['address']['__ansible_unsafe'])
+    host_protocol_version['kafka1-' + instance_suffix] = protocol_version
     kfk2 = testinfra.get_host(
         'kafka2-' + instance_suffix,
         connection='ansible',
@@ -92,6 +96,7 @@ for supported_version in ansible_kafka_supported_versions:
     kfk2_addr = (kfk2.ansible.get_variables()['ansible_eth0']
                  ['ipv4']['address']['__ansible_unsafe'])
 
+    host_protocol_version['kafka2-' + instance_suffix] = protocol_version
     env_sasl.append({
         'protocol_version': protocol_version,
         'zk_addr': zk_addr,
@@ -173,7 +178,7 @@ def call_kafka_lib(
     return results
 
 
-def call_kafka_topic(
+def call_kafka_topic_with_zk(
         localhost,
         args=dict(),
         check=False
@@ -189,6 +194,34 @@ def call_kafka_topic(
         module_args = {
             'api_version': protocol_version,
             'zookeeper': env['zk_addr'],
+            'bootstrap_servers': env['kfk_addr'],
+        }
+        module_args.update(args)
+        module_args = "{{ %s }}" % json.dumps(module_args)
+        results.append(localhost.ansible('kafka_topic',
+                                         module_args, check=check))
+    return results
+
+
+def call_kafka_topic(
+        localhost,
+        args=dict(),
+        check=False,
+        minimal_api_version="0.0.0"
+):
+    results = []
+    if 'sasl_plain_username' in args:
+        envs = env_sasl
+    else:
+        envs = env_no_sasl
+    for env in envs:
+        protocol_version = env['protocol_version']
+        if (parse_version(minimal_api_version) >
+                parse_version(protocol_version)):
+            continue
+
+        module_args = {
+            'api_version': protocol_version,
             'bootstrap_servers': env['kfk_addr'],
         }
         module_args.update(args)
@@ -239,12 +272,21 @@ def ensure_acl(localhost, test_acl_configuration, check=False):
 
 
 def ensure_kafka_topic(localhost, topic_defaut_configuration,
-                       topic_name, check=False):
+                       topic_name, check=False, minimal_api_version="0.0.0"):
     call_config = topic_defaut_configuration.copy()
     call_config.update({
         'name': topic_name
     })
     return call_kafka_topic(localhost, call_config, check)
+
+
+def ensure_kafka_topic_with_zk(localhost, topic_defaut_configuration,
+                               topic_name, check=False):
+    call_config = topic_defaut_configuration.copy()
+    call_config.update({
+        'name': topic_name
+    })
+    return call_kafka_topic_with_zk(localhost, call_config, check)
 
 
 def ensure_kafka_acl(localhost, test_acl_configuration, check=False):

--- a/molecule/default/tests/ansible_utils.py
+++ b/molecule/default/tests/ansible_utils.py
@@ -322,7 +322,7 @@ def check_configured_topic(host, topic_configuration,
                 assert tot_replica == topic_configuration['replica_factor']
 
             for key, value in six.iteritems(topic_configuration['options']):
-                config = kafka_client.get_config_for_topic(topic_name, key)
+                config = kafka_client.get_config_for_topic(topic_name, [key])
                 assert str(config) == str(value)
 
             for key, value in six.iteritems(deleted_options):

--- a/molecule/default/tests/ansible_utils.py
+++ b/molecule/default/tests/ansible_utils.py
@@ -294,7 +294,7 @@ def ensure_kafka_acl(localhost, test_acl_configuration, check=False):
 
 
 def check_configured_topic(host, topic_configuration,
-                           topic_name, kafka_servers):
+                           topic_name, kafka_servers, deleted_options=None):
     """
     Test if topic configuration is what was defined
     """
@@ -304,6 +304,9 @@ def check_configured_topic(host, topic_configuration,
         bootstrap_servers=kafka_servers,
         api_version=(0, 11, 0)
     )
+
+    if deleted_options is None:
+        deleted_options = {}
 
     try:
         if topic_configuration['state'] == 'present':
@@ -321,6 +324,11 @@ def check_configured_topic(host, topic_configuration,
             for key, value in six.iteritems(topic_configuration['options']):
                 config = kafka_client.get_config_for_topic(topic_name, key)
                 assert str(config) == str(value)
+
+            for key, value in six.iteritems(deleted_options):
+                config = kafka_client.get_config_for_topic(topic_name, key)
+                assert str(config) != str(value)
+
         else:
             assert topic_name not in kafka_client.get_topics()
     finally:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -207,6 +207,50 @@ def test_add_options():
                                topic_name, kfk_addr)
 
 
+def test_delete_options():
+    """
+    Check if can remove topic options
+    """
+    # Given
+    init_topic_configuration = topic_defaut_configuration.copy()
+    init_topic_configuration.update({
+        'options': {
+            'retention.ms': 66574936,
+            'flush.ms': 564939
+        }
+    })
+    topic_name = get_topic_name()
+    ensure_topic(
+        localhost,
+        init_topic_configuration,
+        topic_name
+    )
+    time.sleep(0.5)
+    # When
+    test_topic_configuration = topic_defaut_configuration.copy()
+    test_topic_configuration.update({
+        'options': {
+            'flush.ms': 564939
+        }
+    })
+    ensure_topic(
+        localhost,
+        test_topic_configuration,
+        topic_name
+    )
+    time.sleep(0.5)
+    # Then
+    deleted_options = {
+        'retention.ms': 66574936,
+    }
+    for host, host_vars in kafka_hosts.items():
+        kfk_addr = "%s:9092" % \
+            host_vars['ansible_eth0']['ipv4']['address']['__ansible_unsafe']
+        check_configured_topic(host, test_topic_configuration,
+                               topic_name, kfk_addr,
+                               deleted_options=deleted_options)
+
+
 def test_delete_topic():
     """
     Check if can delete topic

--- a/molecule/default/tests/test_topic_default.py
+++ b/molecule/default/tests/test_topic_default.py
@@ -237,6 +237,50 @@ def test_add_options():
                                topic_name, kfk_addr)
 
 
+def test_delete_options():
+    """
+    Check if can remove topic options
+    """
+    # Given
+    init_topic_configuration = topic_defaut_configuration.copy()
+    init_topic_configuration.update({
+        'options': {
+            'retention.ms': 66574936,
+            'flush.ms': 564939
+        }
+    })
+    topic_name = get_topic_name()
+    ensure_kafka_topic(
+        localhost,
+        init_topic_configuration,
+        topic_name
+    )
+    time.sleep(0.5)
+    # When
+    test_topic_configuration = topic_defaut_configuration.copy()
+    test_topic_configuration.update({
+        'options': {
+            'flush.ms': 564939
+        }
+    })
+    ensure_kafka_topic(
+        localhost,
+        test_topic_configuration,
+        topic_name
+    )
+    time.sleep(0.5)
+    # Then
+    deleted_options = {
+        'retention.ms': 66574936,
+    }
+    for host, host_vars in kafka_hosts.items():
+        kfk_addr = "%s:9092" % \
+            host_vars['ansible_eth0']['ipv4']['address']['__ansible_unsafe']
+        check_configured_topic(host, test_topic_configuration,
+                               topic_name, kfk_addr,
+                               deleted_options=deleted_options)
+
+
 def test_delete_topic():
     """
     Check if can delete topic

--- a/molecule/default/tests/test_topic_default.py
+++ b/molecule/default/tests/test_topic_default.py
@@ -237,6 +237,43 @@ def test_add_options():
                                topic_name, kfk_addr)
 
 
+def test_update_itempotent_options():
+    """
+    Check if can remove topic options
+    """
+    # Given
+    topic_name = get_topic_name()
+    ensure_kafka_topic(
+        localhost,
+        topic_defaut_configuration,
+        topic_name
+    )
+    time.sleep(0.5)
+    # When
+    test_topic_configuration = topic_defaut_configuration.copy()
+    test_topic_configuration.update({
+        'options': {
+            'flush.ms': 564939
+        }
+    })
+    changes = ensure_kafka_topic(
+        localhost,
+        test_topic_configuration,
+        topic_name
+    )
+    for change in changes:
+        assert change['changed']
+    changes = ensure_kafka_topic(
+        localhost,
+        test_topic_configuration,
+        topic_name
+    )
+    time.sleep(0.5)
+    # Then
+    for change in changes:
+        assert not change['changed']
+
+
 def test_delete_options():
     """
     Check if can remove topic options

--- a/molecule/default/tests/utils.py
+++ b/molecule/default/tests/utils.py
@@ -9,7 +9,9 @@ from kafka.protocol.types import (
     Array, Boolean, Int8, Int16, Int32, Schema, String
 )
 from kafka.protocol.api import Request, Response
-from kafka.protocol.admin import DescribeAclsRequest_v0
+from kafka.protocol.admin import (
+    DescribeAclsRequest_v0
+)
 
 
 class DescribeConfigsResponseV0(Response):
@@ -115,7 +117,7 @@ class KafkaManager(object):
         Returns value for config_name topic option
         """
         request = DescribeConfigsRequestV0(
-            resources=[(self.TOPIC_RESOURCE_ID, topic_name, [config_name])]
+            resources=[(self.TOPIC_RESOURCE_ID, topic_name, config_name)]
         )
         response = self.send_request_and_get_response(request)
         for err_code, err_message, _, _, config_entries in response.resources:


### PR DESCRIPTION
Fixes #63 

## Proposed Changes

  - Use Kafka API most of the time
  - No longer need to use zookeeper if Kafka >= 2.4.0
