### PR TITLE
Test for idempotency of Ansible calls

### DIFF
--- a/molecule/default/tests/ansible_utils.py
+++ b/molecule/default/tests/ansible_utils.py
@@ -111,9 +111,11 @@ for supported_version in ansible_kafka_supported_versions:
 
 def call_kafka_stat_lag(
         localhost,
-        args=dict()
+        args=None
 ):
     results = []
+    if args is None:
+        args = {}
     if 'sasl_plain_username' in args:
         envs = env_sasl
     else:
@@ -133,9 +135,11 @@ def call_kafka_stat_lag(
 
 def call_kafka_info(
         localhost,
-        args=dict()
+        args=None
 ):
     results = []
+    if args is None:
+        args = {}
     if 'sasl_plain_username' in args:
         envs = env_sasl
     else:
@@ -155,10 +159,12 @@ def call_kafka_info(
 
 def call_kafka_lib(
         localhost,
-        args=dict(),
+        args=None,
         check=False
 ):
     results = []
+    if args is None:
+        args = {}
     if 'sasl_plain_username' in args:
         envs = env_sasl
     else:
@@ -180,10 +186,12 @@ def call_kafka_lib(
 
 def call_kafka_topic_with_zk(
         localhost,
-        args=dict(),
+        args=None,
         check=False
 ):
     results = []
+    if args is None:
+        args = {}
     if 'sasl_plain_username' in args:
         envs = env_sasl
     else:
@@ -205,11 +213,13 @@ def call_kafka_topic_with_zk(
 
 def call_kafka_topic(
         localhost,
-        args=dict(),
+        args=None,
         check=False,
         minimal_api_version="0.0.0"
 ):
     results = []
+    if args is None:
+        args = {}
     if 'sasl_plain_username' in args:
         envs = env_sasl
     else:
@@ -233,10 +243,12 @@ def call_kafka_topic(
 
 def call_kafka_acl(
         localhost,
-        args=dict(),
+        args=None,
         check=False
 ):
     results = []
+    if args is None:
+        args = {}
     if 'sasl_plain_username' in args:
         envs = env_sasl
     else:
@@ -277,7 +289,9 @@ def ensure_kafka_topic(localhost, topic_defaut_configuration,
     call_config.update({
         'name': topic_name
     })
-    return call_kafka_topic(localhost, call_config, check)
+    return call_kafka_topic(
+        localhost, call_config, check, minimal_api_version=minimal_api_version
+    )
 
 
 def ensure_kafka_topic_with_zk(localhost, topic_defaut_configuration,
@@ -400,3 +414,17 @@ def produce_and_consume_topic(topic_name, total_msg, consumer_group):
         # will commit offset to 1
         consumer.commit()
         # voluntary dont close the client to keep the consumer group alive
+
+
+def ensure_idempotency(func, *args, **kwargs):
+    """
+    Ensure an Ansible call `func` is idempotent:
+      - 1st call 'changed' result is True
+      - 2nd call 'changed' result is False
+    """
+    changes = func(*args, **kwargs)
+    for change in changes:
+        assert change['changed']
+    changes = func(*args, **kwargs)
+    for change in changes:
+        assert not change['changed']

--- a/molecule/default/tests/test_acl_default.py
+++ b/molecule/default/tests/test_acl_default.py
@@ -10,7 +10,7 @@ from tests.ansible_utils import (
     acl_defaut_configuration,
     sasl_default_configuration,
     ensure_kafka_acl,
-    check_configured_acl
+    check_configured_acl, ensure_idempotency
 )
 
 runner = testinfra.utils.ansible_runner.AnsibleRunner(
@@ -51,7 +51,8 @@ def test_acl_create():
     test_acl_configuration.update({
         'state': 'present'
     })
-    ensure_kafka_acl(
+    ensure_idempotency(
+        ensure_kafka_acl,
         localhost,
         test_acl_configuration
     )
@@ -82,7 +83,8 @@ def test_acl_delete():
     test_acl_configuration.update({
         'state': 'absent'
     })
-    ensure_kafka_acl(
+    ensure_idempotency(
+        ensure_kafka_acl,
         localhost,
         test_acl_configuration
     )

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -19,7 +19,8 @@ from tests.ansible_utils import (
     call_kafka_info,
     check_configured_topic,
     check_configured_acl,
-    produce_and_consume_topic
+    produce_and_consume_topic,
+    ensure_idempotency
 )
 
 runner = testinfra.utils.ansible_runner.AnsibleRunner(
@@ -58,7 +59,8 @@ def test_update_replica_factor():
     test_topic_configuration.update({
         'replica_factor': 2
     })
-    ensure_topic(
+    ensure_idempotency(
+        ensure_topic,
         localhost,
         test_topic_configuration,
         topic_name
@@ -89,7 +91,8 @@ def test_update_partitions():
     test_topic_configuration.update({
         'partitions': 2
     })
-    ensure_topic(
+    ensure_idempotency(
+        ensure_topic,
         localhost,
         test_topic_configuration,
         topic_name
@@ -121,7 +124,8 @@ def test_update_partitions_and_replica_factor():
         'partitions': 4,
         'replica_factor': 2
     })
-    ensure_topic(
+    ensure_idempotency(
+        ensure_topic,
         localhost,
         test_topic_configuration,
         topic_name
@@ -193,7 +197,8 @@ def test_add_options():
             'flush.ms': 564939
         }
     })
-    ensure_topic(
+    ensure_idempotency(
+        ensure_topic,
         localhost,
         test_topic_configuration,
         topic_name
@@ -233,7 +238,8 @@ def test_delete_options():
             'flush.ms': 564939
         }
     })
-    ensure_topic(
+    ensure_idempotency(
+        ensure_topic,
         localhost,
         test_topic_configuration,
         topic_name
@@ -268,7 +274,8 @@ def test_delete_topic():
     test_topic_configuration.update({
         'state': 'absent'
     })
-    ensure_topic(
+    ensure_idempotency(
+        ensure_topic,
         localhost,
         test_topic_configuration,
         topic_name
@@ -301,7 +308,8 @@ def test_acl_create():
     test_acl_configuration.update({
         'state': 'present'
     })
-    ensure_acl(
+    ensure_idempotency(
+        ensure_acl,
         localhost,
         test_acl_configuration
     )
@@ -332,7 +340,8 @@ def test_acl_delete():
     test_acl_configuration.update({
         'state': 'absent'
     })
-    ensure_acl(
+    ensure_idempotency(
+        ensure_acl,
         localhost,
         test_acl_configuration
     )

--- a/molecule/default/tests/test_topic_default.py
+++ b/molecule/default/tests/test_topic_default.py
@@ -13,7 +13,7 @@ from tests.ansible_utils import (
     ensure_kafka_topic,
     ensure_kafka_topic_with_zk,
     check_configured_topic,
-    host_protocol_version
+    host_protocol_version, ensure_idempotency
 )
 
 runner = testinfra.utils.ansible_runner.AnsibleRunner(
@@ -52,7 +52,8 @@ def test_update_replica_factor():
     test_topic_configuration.update({
         'replica_factor': 2
     })
-    ensure_kafka_topic_with_zk(
+    ensure_idempotency(
+        ensure_kafka_topic_with_zk,
         localhost,
         test_topic_configuration,
         topic_name
@@ -83,7 +84,8 @@ def test_update_partitions():
     test_topic_configuration.update({
         'partitions': 2
     })
-    ensure_kafka_topic_with_zk(
+    ensure_idempotency(
+        ensure_kafka_topic_with_zk,
         localhost,
         test_topic_configuration,
         topic_name
@@ -114,7 +116,8 @@ def test_update_partitions_without_zk():
     test_topic_configuration.update({
         'partitions': 2
     })
-    ensure_kafka_topic(
+    ensure_idempotency(
+        ensure_kafka_topic,
         localhost,
         test_topic_configuration,
         topic_name,
@@ -151,7 +154,8 @@ def test_update_partitions_and_replica_factor():
         'partitions': 4,
         'replica_factor': 2
     })
-    ensure_kafka_topic_with_zk(
+    ensure_idempotency(
+        ensure_kafka_topic_with_zk,
         localhost,
         test_topic_configuration,
         topic_name
@@ -223,7 +227,8 @@ def test_add_options():
             'flush.ms': 564939
         }
     })
-    ensure_kafka_topic(
+    ensure_idempotency(
+        ensure_kafka_topic,
         localhost,
         test_topic_configuration,
         topic_name
@@ -235,43 +240,6 @@ def test_add_options():
             host_vars['ansible_eth0']['ipv4']['address']['__ansible_unsafe']
         check_configured_topic(host, test_topic_configuration,
                                topic_name, kfk_addr)
-
-
-def test_update_itempotent_options():
-    """
-    Check if can remove topic options
-    """
-    # Given
-    topic_name = get_topic_name()
-    ensure_kafka_topic(
-        localhost,
-        topic_defaut_configuration,
-        topic_name
-    )
-    time.sleep(0.5)
-    # When
-    test_topic_configuration = topic_defaut_configuration.copy()
-    test_topic_configuration.update({
-        'options': {
-            'flush.ms': 564939
-        }
-    })
-    changes = ensure_kafka_topic(
-        localhost,
-        test_topic_configuration,
-        topic_name
-    )
-    for change in changes:
-        assert change['changed']
-    changes = ensure_kafka_topic(
-        localhost,
-        test_topic_configuration,
-        topic_name
-    )
-    time.sleep(0.5)
-    # Then
-    for change in changes:
-        assert not change['changed']
 
 
 def test_delete_options():
@@ -300,7 +268,8 @@ def test_delete_options():
             'flush.ms': 564939
         }
     })
-    ensure_kafka_topic(
+    ensure_idempotency(
+        ensure_kafka_topic,
         localhost,
         test_topic_configuration,
         topic_name
@@ -335,7 +304,8 @@ def test_delete_topic():
     test_topic_configuration.update({
         'state': 'absent'
     })
-    ensure_kafka_topic(
+    ensure_idempotency(
+        ensure_kafka_topic,
         localhost,
         test_topic_configuration,
         topic_name


### PR DESCRIPTION
## Proposed Changes

- Add an `ensure_idempotency` func that performs 2 calls and check for 'changed' result
- Make sure `minimal_api_version` kw is passed to `call_kafka_topic` func
- Just in case, remove usage of mutable objects as default kw value to avoid possible side effects