### PR TITLE
Add some real-life examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 *.log
 ansible_cache/
 *.pyc
+roles
+venv

--- a/README.md
+++ b/README.md
@@ -24,10 +24,12 @@ Add the following requirement in your playbook's **requirements.yml**:
 ```
 ## Usage
 ### Creating, updating, deleting topics and ACLs
-**Note**
+**Note**:
 Zookeeper is only needed when:
 * replication-factor changed with Kafka < 2.4.0
 * Kafka <= 0.11.0
+
+See the [`examples`](examples) folder for real-life examples.
 
 Here some examples on how to use this library:
 ```yaml

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,44 @@
+# Library usage examples
+## Common
+For each example, you will find:
+* a `docker-compose.yml` file to bring up the minimum services required to use the example
+* a `playbook.yml` that performs some actions using the library
+
+## Usage
+Make sure to `cd` in the folder `examples`.
+1. Create a virtualenv and source it
+```bash
+virtualen venv -p python3 && source venv/bin/activate
+```
+2. Install requirements
+```bash
+pip install -r ../requirements.txt
+```
+3. Install Ansible
+```bash
+pip install ansible
+```
+4. Install roles
+```bash
+ansible-galaxy install -r requirements.yml
+```
+5. Bring up the needed stack
+```bash
+docker-compose -f ${folder}/docker-compose.yml up -d
+```
+6. Trigger the playbook
+```bash
+ansible-playbook ${folder}/playbook.yml -v
+```
+## Examples
+### topic-creation
+Create a topic.
+
+### topic-partition-update
+Create a topic and update its number of partitions.
+
+### topic-replica-update
+Create a topic and update its number of replica.
+
+### topic-options-update
+Create a topic and update the `retention.ms` configuration.

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = ./roles

--- a/examples/requirements.yml
+++ b/examples/requirements.yml
@@ -1,0 +1,3 @@
+# from GitHub, overriding the name and specifying a specific tag
+- src: https://github.com/StephenSorriaux/ansible-kafka-admin
+  name: kafka_lib

--- a/examples/requirements.yml
+++ b/examples/requirements.yml
@@ -1,3 +1,4 @@
+---
 # from GitHub, overriding the name and specifying a specific tag
 - src: https://github.com/StephenSorriaux/ansible-kafka-admin
   name: kafka_lib

--- a/examples/topic-creation/docker-compose.yml
+++ b/examples/topic-creation/docker-compose.yml
@@ -1,19 +1,19 @@
 ---
 version: '2'
 services:
- zookeeper:
-   image: zookeeper:3.6
-   command: "bin/zkServer.sh start-foreground"
-   network_mode: "host"
-   container_name: zookeeper
- kafka:
-   image: wurstmeister/kafka:2.13-2.6.0
-   command: "start-kafka.sh"
-   container_name: kafka
-   network_mode: "host"
-   environment:
-     KAFKA_DELETE_TOPIC_ENABLE: "true"
-     KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
-     KAFKA_LISTENERS: PLAINTEXT://:9092
-     KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-     KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+  zookeeper:
+    image: zookeeper:3.6
+    command: "bin/zkServer.sh start-foreground"
+    network_mode: "host"
+    container_name: zookeeper
+  kafka:
+    image: wurstmeister/kafka:2.13-2.6.0
+    command: "start-kafka.sh"
+    container_name: kafka
+    network_mode: "host"
+    environment:
+      KAFKA_DELETE_TOPIC_ENABLE: "true"
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_LISTENERS: PLAINTEXT://:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_ZOOKEEPER_CONNECT: localhost:2181

--- a/examples/topic-creation/docker-compose.yml
+++ b/examples/topic-creation/docker-compose.yml
@@ -1,0 +1,19 @@
+---
+version: '2'
+services:
+ zookeeper:
+   image: zookeeper:3.6
+   command: "bin/zkServer.sh start-foreground"
+   network_mode: "host"
+   container_name: zookeeper
+ kafka:
+   image: wurstmeister/kafka:2.13-2.6.0
+   command: "start-kafka.sh"
+   container_name: kafka
+   network_mode: "host"
+   environment:
+     KAFKA_DELETE_TOPIC_ENABLE: "true"
+     KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+     KAFKA_LISTENERS: PLAINTEXT://:9092
+     KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+     KAFKA_ZOOKEEPER_CONNECT: localhost:2181

--- a/examples/topic-creation/playbook.yml
+++ b/examples/topic-creation/playbook.yml
@@ -1,3 +1,4 @@
+---
 - name: Example | Topic creation
   hosts: 127.0.0.1
   roles:

--- a/examples/topic-creation/playbook.yml
+++ b/examples/topic-creation/playbook.yml
@@ -1,0 +1,24 @@
+- name: Example | Topic creation
+  hosts: 127.0.0.1
+  roles:
+    - name: kafka_lib
+  post_tasks:
+    - name: "Create topic 'test-topic-creation'"
+      kafka_topic:
+        api_version: "2.6.0"
+        name: "test-topic-creation"
+        partitions: 2
+        replica_factor: 1
+        bootstrap_servers: "localhost:9092"
+        state: "present"
+
+    - name: "Get topics information"
+      kafka_info:
+        resource: "topic"
+        api_version: "2.6.0"
+        bootstrap_servers: "localhost:9092"
+      register: topics
+
+    - name: "Display results"
+      debug:
+        var: topics['ansible_module_results']['test-topic-creation']

--- a/examples/topic-options-update/docker-compose.yml
+++ b/examples/topic-options-update/docker-compose.yml
@@ -1,19 +1,19 @@
 ---
 version: '2'
 services:
- zookeeper:
-   image: zookeeper:3.6
-   command: "bin/zkServer.sh start-foreground"
-   network_mode: "host"
-   container_name: zookeeper
- kafka:
-   image: wurstmeister/kafka:2.13-2.6.0
-   command: "start-kafka.sh"
-   container_name: kafka
-   network_mode: "host"
-   environment:
-     KAFKA_DELETE_TOPIC_ENABLE: "true"
-     KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
-     KAFKA_LISTENERS: PLAINTEXT://:9092
-     KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-     KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+  zookeeper:
+    image: zookeeper:3.6
+    command: "bin/zkServer.sh start-foreground"
+    network_mode: "host"
+    container_name: zookeeper
+  kafka:
+    image: wurstmeister/kafka:2.13-2.6.0
+    command: "start-kafka.sh"
+    container_name: kafka
+    network_mode: "host"
+    environment:
+      KAFKA_DELETE_TOPIC_ENABLE: "true"
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_LISTENERS: PLAINTEXT://:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_ZOOKEEPER_CONNECT: localhost:2181

--- a/examples/topic-options-update/docker-compose.yml
+++ b/examples/topic-options-update/docker-compose.yml
@@ -1,0 +1,19 @@
+---
+version: '2'
+services:
+ zookeeper:
+   image: zookeeper:3.6
+   command: "bin/zkServer.sh start-foreground"
+   network_mode: "host"
+   container_name: zookeeper
+ kafka:
+   image: wurstmeister/kafka:2.13-2.6.0
+   command: "start-kafka.sh"
+   container_name: kafka
+   network_mode: "host"
+   environment:
+     KAFKA_DELETE_TOPIC_ENABLE: "true"
+     KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+     KAFKA_LISTENERS: PLAINTEXT://:9092
+     KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+     KAFKA_ZOOKEEPER_CONNECT: localhost:2181

--- a/examples/topic-options-update/playbook.yml
+++ b/examples/topic-options-update/playbook.yml
@@ -1,0 +1,35 @@
+- name: Example | Topic options update
+  hosts: 127.0.0.1
+  roles:
+    - name: kafka_lib
+  post_tasks:
+    - name: "Create topic 'test-topic-options-update'"
+      kafka_topic:
+        api_version: "2.6.0"
+        name: "test-topic-options-update"
+        partitions: 2
+        replica_factor: 1
+        bootstrap_servers: "localhost:9092"
+        state: "present"
+
+    - name: "Create topic 'test-topic-options-update'"
+      kafka_topic:
+        api_version: "2.6.0"
+        name: "test-topic-options-update"
+        options:
+          retention.ms: 1234567
+        partitions: 2
+        replica_factor: 1
+        bootstrap_servers: "localhost:9092"
+        state: "present"
+
+    - name: "Get topics information"
+      kafka_info:
+        resource: "topic"
+        api_version: "2.6.0"
+        bootstrap_servers: "localhost:9092"
+      register: topics
+
+    - name: "Display results"
+      debug:
+        var: topics['ansible_module_results']['test-topic-options-update']

--- a/examples/topic-options-update/playbook.yml
+++ b/examples/topic-options-update/playbook.yml
@@ -1,3 +1,4 @@
+---
 - name: Example | Topic options update
   hosts: 127.0.0.1
   roles:

--- a/examples/topic-partition-update/docker-compose.yml
+++ b/examples/topic-partition-update/docker-compose.yml
@@ -1,19 +1,19 @@
 ---
 version: '2'
 services:
- zookeeper:
-   image: zookeeper:3.6
-   command: "bin/zkServer.sh start-foreground"
-   network_mode: "host"
-   container_name: zookeeper
- kafka:
-   image: wurstmeister/kafka:2.13-2.6.0
-   command: "start-kafka.sh"
-   container_name: kafka
-   network_mode: "host"
-   environment:
-     KAFKA_DELETE_TOPIC_ENABLE: "true"
-     KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
-     KAFKA_LISTENERS: PLAINTEXT://:9092
-     KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-     KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+  zookeeper:
+    image: zookeeper:3.6
+    command: "bin/zkServer.sh start-foreground"
+    network_mode: "host"
+    container_name: zookeeper
+  kafka:
+    image: wurstmeister/kafka:2.13-2.6.0
+    command: "start-kafka.sh"
+    container_name: kafka
+    network_mode: "host"
+    environment:
+      KAFKA_DELETE_TOPIC_ENABLE: "true"
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_LISTENERS: PLAINTEXT://:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_ZOOKEEPER_CONNECT: localhost:2181

--- a/examples/topic-partition-update/docker-compose.yml
+++ b/examples/topic-partition-update/docker-compose.yml
@@ -1,0 +1,19 @@
+---
+version: '2'
+services:
+ zookeeper:
+   image: zookeeper:3.6
+   command: "bin/zkServer.sh start-foreground"
+   network_mode: "host"
+   container_name: zookeeper
+ kafka:
+   image: wurstmeister/kafka:2.13-2.6.0
+   command: "start-kafka.sh"
+   container_name: kafka
+   network_mode: "host"
+   environment:
+     KAFKA_DELETE_TOPIC_ENABLE: "true"
+     KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+     KAFKA_LISTENERS: PLAINTEXT://:9092
+     KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+     KAFKA_ZOOKEEPER_CONNECT: localhost:2181

--- a/examples/topic-partition-update/playbook.yml
+++ b/examples/topic-partition-update/playbook.yml
@@ -1,0 +1,33 @@
+- name: Example | Topic partition update
+  hosts: 127.0.0.1
+  roles:
+    - name: kafka_lib
+  post_tasks:
+    - name: "Create topic 'test-topic-partition-update'"
+      kafka_topic:
+        api_version: "2.6.0"
+        name: "test-topic-partition-update"
+        partitions: 2
+        replica_factor: 1
+        bootstrap_servers: "localhost:9092"
+        state: "present"
+
+    - name: "Update topic 'test-topic-partition-update'"
+      kafka_topic:
+        api_version: "2.6.0"
+        name: "test-topic-partition-update"
+        partitions: 4
+        replica_factor: 1
+        bootstrap_servers: "localhost:9092"
+        state: "present"
+
+    - name: "Get topics information"
+      kafka_info:
+        resource: "topic"
+        api_version: "2.6.0"
+        bootstrap_servers: "localhost:9092"
+      register: topics
+
+    - name: "Display results"
+      debug:
+        var: topics['ansible_module_results']['test-topic-partition-update']

--- a/examples/topic-partition-update/playbook.yml
+++ b/examples/topic-partition-update/playbook.yml
@@ -1,3 +1,4 @@
+---
 - name: Example | Topic partition update
   hosts: 127.0.0.1
   roles:

--- a/examples/topic-replica-update/docker-compose.yml
+++ b/examples/topic-replica-update/docker-compose.yml
@@ -1,0 +1,30 @@
+---
+version: '2'
+services:
+ zookeeper:
+   image: zookeeper:3.6
+   command: "bin/zkServer.sh start-foreground"
+   network_mode: "host"
+   container_name: zookeeper
+ kafka1:
+   image: wurstmeister/kafka:2.13-2.6.0
+   command: "start-kafka.sh"
+   container_name: kafka1
+   network_mode: "host"
+   environment:
+     KAFKA_DELETE_TOPIC_ENABLE: "true"
+     KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+     KAFKA_LISTENERS: PLAINTEXT://:9092
+     KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+     KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+ kafka2:
+   image: wurstmeister/kafka:2.13-2.6.0
+   command: "start-kafka.sh"
+   container_name: kafka2
+   network_mode: "host"
+   environment:
+     KAFKA_DELETE_TOPIC_ENABLE: "true"
+     KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9093
+     KAFKA_LISTENERS: PLAINTEXT://:9093
+     KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+     KAFKA_ZOOKEEPER_CONNECT: localhost:2181

--- a/examples/topic-replica-update/docker-compose.yml
+++ b/examples/topic-replica-update/docker-compose.yml
@@ -1,30 +1,30 @@
 ---
 version: '2'
 services:
- zookeeper:
-   image: zookeeper:3.6
-   command: "bin/zkServer.sh start-foreground"
-   network_mode: "host"
-   container_name: zookeeper
- kafka1:
-   image: wurstmeister/kafka:2.13-2.6.0
-   command: "start-kafka.sh"
-   container_name: kafka1
-   network_mode: "host"
-   environment:
-     KAFKA_DELETE_TOPIC_ENABLE: "true"
-     KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
-     KAFKA_LISTENERS: PLAINTEXT://:9092
-     KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-     KAFKA_ZOOKEEPER_CONNECT: localhost:2181
- kafka2:
-   image: wurstmeister/kafka:2.13-2.6.0
-   command: "start-kafka.sh"
-   container_name: kafka2
-   network_mode: "host"
-   environment:
-     KAFKA_DELETE_TOPIC_ENABLE: "true"
-     KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9093
-     KAFKA_LISTENERS: PLAINTEXT://:9093
-     KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-     KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+  zookeeper:
+    image: zookeeper:3.6
+    command: "bin/zkServer.sh start-foreground"
+    network_mode: "host"
+    container_name: zookeeper
+  kafka1:
+    image: wurstmeister/kafka:2.13-2.6.0
+    command: "start-kafka.sh"
+    container_name: kafka1
+    network_mode: "host"
+    environment:
+      KAFKA_DELETE_TOPIC_ENABLE: "true"
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_LISTENERS: PLAINTEXT://:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+  kafka2:
+    image: wurstmeister/kafka:2.13-2.6.0
+    command: "start-kafka.sh"
+    container_name: kafka2
+    network_mode: "host"
+    environment:
+      KAFKA_DELETE_TOPIC_ENABLE: "true"
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9093
+      KAFKA_LISTENERS: PLAINTEXT://:9093
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_ZOOKEEPER_CONNECT: localhost:2181

--- a/examples/topic-replica-update/playbook.yml
+++ b/examples/topic-replica-update/playbook.yml
@@ -1,3 +1,4 @@
+---
 - name: Example | Topic replica update
   hosts: 127.0.0.1
   roles:

--- a/examples/topic-replica-update/playbook.yml
+++ b/examples/topic-replica-update/playbook.yml
@@ -1,0 +1,33 @@
+- name: Example | Topic replica update
+  hosts: 127.0.0.1
+  roles:
+    - name: kafka_lib
+  post_tasks:
+    - name: "Create topic 'test-topic-replica-update'"
+      kafka_topic:
+        api_version: "2.6.0"
+        name: "test-topic-replica-update"
+        partitions: 2
+        replica_factor: 1
+        bootstrap_servers: "localhost:9092,localhost:9093"
+        state: "present"
+
+    - name: "Update topic 'test-topic-replica-update'"
+      kafka_topic:
+        api_version: "2.6.0"
+        name: "test-topic-replica-update"
+        partitions: 2
+        replica_factor: 2
+        bootstrap_servers: "localhost:9092,localhost:9093"
+        state: "present"
+
+    - name: "Get topics information"
+      kafka_info:
+        resource: "topic"
+        api_version: "2.6.0"
+        bootstrap_servers: "localhost:9092"
+      register: topics
+
+    - name: "Display results"
+      debug:
+        var: topics['ansible_module_results']['test-topic-replica-update']


### PR DESCRIPTION
Relates to https://github.com/StephenSorriaux/ansible-kafka-admin/issues/69

## Proposed Changes

  - add `examples` folder with some basic examples for `kafka_topic` module