### PR TITLE
Dissociate python version from test tools & tested version.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,11 +9,10 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python_version: [2-slim, 3.5-slim, 3.6-slim, 3.7-slim, 3.8-slim, 3.9-slim]
 
     steps:
       - uses: actions/checkout@v2
@@ -21,10 +20,10 @@ jobs:
         run: |
           set -e
           docker info
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.9
       - name: Install dependencies
         run: |
           pip install -r test-requirements.txt
@@ -32,8 +31,9 @@ jobs:
       - name: Lint with flake8
         run: |
           flake8 .
-      - name: Test with molecule
+      - name: Test with molecule ${{ matrix.python_version }}
         run: |
+          export PYTHON_VERSION=${{ matrix.python_version }}
           export ANSIBLE_MODULE_UTILS=$PWD/module_utils
           molecule create
           molecule converge

--- a/README.md
+++ b/README.md
@@ -371,7 +371,8 @@ cacert_content: |
 ```
 ## Python compatibility
 This library is tested with the following versions of Python:
-* Python 2.7 (EOL last version 0.11.0)
+* Python 2.7
+* Python 3.5
 * Python 3.6
 * Python 3.7
 * Python 3.8

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,6 +6,23 @@ driver:
 lint: |
   yamllint .
 platforms:
+  #########################################################
+  # Executors
+  #########################################################
+  # Python 2 support
+  - name: python-${PYTHON_VERSION:-2-slim}
+    image: python:${PYTHON_VERSION:-2-slim}
+    command: >-
+      /bin/bash -c '/usr/local/bin/python -m pip install -r /src/requirements.txt && trap : TERM INT; sleep infinity & wait'
+    volumes:
+      - ${MOLECULE_PROJECT_DIRECTORY}:/src
+    groups:
+      - executors
+    networks:
+      - name: molecule
+  #########################################################
+  # Kafka env
+  #########################################################
   # 0.11.0.3
   - name: zookeeper-01103
     image: zookeeper:3.4
@@ -217,6 +234,8 @@ provisioner:
     name: ansible-lint
   inventory:
     group_vars:
+      executors:
+        ansible_python_interpreter: /usr/local/bin/python
       all:
         ansible_kafka_supported_versions:
           - protocol_version: "0.11.0"
@@ -244,13 +263,14 @@ scenario:
     - prepare
   converge_sequence:
     - converge
-    - idempotence
-    - side_effect
     - verify
 verifier:
   name: testinfra
   options:
+    instafail: true
     s: true
     l: true
+    verbose: true
+    n: "auto"
   lint:
     name: flake8

--- a/molecule/default/tests/ansible_utils.py
+++ b/molecule/default/tests/ansible_utils.py
@@ -5,11 +5,12 @@ import six
 import testinfra
 
 from pkg_resources import parse_version
-from datetime import datetime
 
 from tests.utils import KafkaManager
 
 from kafka import KafkaConsumer, KafkaProducer
+
+import uuid
 
 
 def get_molecule_configuration():
@@ -19,19 +20,15 @@ def get_molecule_configuration():
 
 
 def get_topic_name():
-    # current date and time
-    now = datetime.now()
+    return "test_" + str(uuid.uuid4())
 
-    timestamp = datetime.timestamp(now)
-    return "test_" + str(timestamp)
+
+def get_acl_name():
+    return "test_" + str(uuid.uuid4())
 
 
 def get_consumer_group():
-    # current date and time
-    now = datetime.now()
-
-    timestamp = datetime.timestamp(now)
-    return "AWESOME_consumer_group_" + str(timestamp)
+    return "AWESOME_consumer_group_" + str(uuid.uuid4())
 
 
 molecule_configuration = get_molecule_configuration()
@@ -45,7 +42,6 @@ topic_defaut_configuration = {
 
 acl_defaut_configuration = {
     'acl_resource_type': 'topic',
-    'name': 'test-acl',
     'state': 'absent',
     'acl_principal': 'User:common',
     'acl_operation': 'write',
@@ -110,7 +106,7 @@ for supported_version in ansible_kafka_supported_versions:
 
 
 def call_kafka_stat_lag(
-        localhost,
+        host,
         args=None
 ):
     results = []
@@ -128,13 +124,13 @@ def call_kafka_stat_lag(
         }
         module_args.update(args)
         module_args = "{{ %s }}" % json.dumps(module_args)
-        results.append(localhost.ansible('kafka_stat_lag',
-                                         module_args, check=False))
+        results.append(host.ansible('kafka_stat_lag',
+                                    module_args, check=False))
     return results
 
 
 def call_kafka_info(
-        localhost,
+        host,
         args=None
 ):
     results = []
@@ -152,13 +148,13 @@ def call_kafka_info(
         }
         module_args.update(args)
         module_args = "{{ %s }}" % json.dumps(module_args)
-        results.append(localhost.ansible('kafka_info',
-                                         module_args, check=False))
+        results.append(host.ansible('kafka_info',
+                                    module_args, check=False))
     return results
 
 
 def call_kafka_lib(
-        localhost,
+        host,
         args=None,
         check=False
 ):
@@ -179,13 +175,13 @@ def call_kafka_lib(
         }
         module_args.update(args)
         module_args = "{{ %s }}" % json.dumps(module_args)
-        results.append(localhost.ansible('kafka_lib',
-                                         module_args, check=check))
+        results.append(host.ansible('kafka_lib',
+                                    module_args, check=check))
     return results
 
 
 def call_kafka_topic_with_zk(
-        localhost,
+        host,
         args=None,
         check=False
 ):
@@ -206,13 +202,13 @@ def call_kafka_topic_with_zk(
         }
         module_args.update(args)
         module_args = "{{ %s }}" % json.dumps(module_args)
-        results.append(localhost.ansible('kafka_topic',
-                                         module_args, check=check))
+        results.append(host.ansible('kafka_topic',
+                                    module_args, check=check))
     return results
 
 
 def call_kafka_topic(
-        localhost,
+        host,
         args=None,
         check=False,
         minimal_api_version="0.0.0"
@@ -236,13 +232,13 @@ def call_kafka_topic(
         }
         module_args.update(args)
         module_args = "{{ %s }}" % json.dumps(module_args)
-        results.append(localhost.ansible('kafka_topic',
-                                         module_args, check=check))
+        results.append(host.ansible('kafka_topic',
+                                    module_args, check=check))
     return results
 
 
 def call_kafka_acl(
-        localhost,
+        host,
         args=None,
         check=False
 ):
@@ -262,49 +258,49 @@ def call_kafka_acl(
         }
         module_args.update(args)
         module_args = "{{ %s }}" % json.dumps(module_args)
-        results.append(localhost.ansible('kafka_acl',
-                                         module_args, check=check))
+        results.append(host.ansible('kafka_acl',
+                                    module_args, check=check))
     return results
 
 
-def ensure_topic(localhost, topic_defaut_configuration,
+def ensure_topic(host, topic_defaut_configuration,
                  topic_name, check=False):
-    return call_kafka_lib(localhost, {
+    return call_kafka_lib(host, {
         'resource': 'topic',
         'name': topic_name,
         **topic_defaut_configuration
     }, check)
 
 
-def ensure_acl(localhost, test_acl_configuration, check=False):
-    return call_kafka_lib(localhost, {
+def ensure_acl(host, test_acl_configuration, check=False):
+    return call_kafka_lib(host, {
         'resource': 'acl',
         **test_acl_configuration
     }, check)
 
 
-def ensure_kafka_topic(localhost, topic_defaut_configuration,
+def ensure_kafka_topic(host, topic_defaut_configuration,
                        topic_name, check=False, minimal_api_version="0.0.0"):
     call_config = topic_defaut_configuration.copy()
     call_config.update({
         'name': topic_name
     })
     return call_kafka_topic(
-        localhost, call_config, check, minimal_api_version=minimal_api_version
+        host, call_config, check, minimal_api_version=minimal_api_version
     )
 
 
-def ensure_kafka_topic_with_zk(localhost, topic_defaut_configuration,
+def ensure_kafka_topic_with_zk(host, topic_defaut_configuration,
                                topic_name, check=False):
     call_config = topic_defaut_configuration.copy()
     call_config.update({
         'name': topic_name
     })
-    return call_kafka_topic_with_zk(localhost, call_config, check)
+    return call_kafka_topic_with_zk(host, call_config, check)
 
 
-def ensure_kafka_acl(localhost, test_acl_configuration, check=False):
-    return call_kafka_acl(localhost, test_acl_configuration, check)
+def ensure_kafka_acl(host, test_acl_configuration, check=False):
+    return call_kafka_acl(host, test_acl_configuration, check)
 
 
 def check_configured_topic(host, topic_configuration,

--- a/molecule/default/tests/test_acl_default.py
+++ b/molecule/default/tests/test_acl_default.py
@@ -9,19 +9,13 @@ import testinfra.utils.ansible_runner
 from tests.ansible_utils import (
     acl_defaut_configuration,
     sasl_default_configuration,
-    ensure_kafka_acl,
+    ensure_kafka_acl, get_acl_name,
     check_configured_acl, ensure_idempotency
 )
 
 runner = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE'])
-testinfra_hosts = runner.get_hosts('kafka')
-
-localhost = testinfra.get_host(
-    'localhost',
-    connection='ansible',
-    ansible_inventory=os.environ['MOLECULE_INVENTORY_FILE']
-)
+testinfra_hosts = runner.get_hosts('executors')
 
 kafka_hosts = dict()
 for host in testinfra.get_hosts(
@@ -32,31 +26,32 @@ for host in testinfra.get_hosts(
     kafka_hosts[host] = host.ansible.get_variables()
 
 
-def test_acl_create():
+def test_acl_create(host):
     """
     Check if can create acls
     """
     # Given
     test_acl_configuration = acl_defaut_configuration.copy()
     test_acl_configuration.update({
+        'name': get_acl_name(),
         'state': 'absent'
     })
     test_acl_configuration.update(sasl_default_configuration)
     ensure_kafka_acl(
-        localhost,
+        host,
         test_acl_configuration
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     test_acl_configuration.update({
         'state': 'present'
     })
     ensure_idempotency(
         ensure_kafka_acl,
-        localhost,
+        host,
         test_acl_configuration
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
     for host, host_vars in kafka_hosts.items():
         kfk_addr = "%s:9094" % \
@@ -64,31 +59,32 @@ def test_acl_create():
         check_configured_acl(host, test_acl_configuration, kfk_addr)
 
 
-def test_acl_delete():
+def test_acl_delete(host):
     """
     Check if can delete acls
     """
     # Given
     test_acl_configuration = acl_defaut_configuration.copy()
     test_acl_configuration.update({
+        'name': get_acl_name(),
         'state': 'present'
     })
     test_acl_configuration.update(sasl_default_configuration)
     ensure_kafka_acl(
-        localhost,
+        host,
         test_acl_configuration
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     test_acl_configuration.update({
         'state': 'absent'
     })
     ensure_idempotency(
         ensure_kafka_acl,
-        localhost,
+        host,
         test_acl_configuration
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
     for host, host_vars in kafka_hosts.items():
         kfk_addr = "%s:9094" % \
@@ -96,42 +92,43 @@ def test_acl_delete():
         check_configured_acl(host, test_acl_configuration, kfk_addr)
 
 
-def test_check_mode():
+def test_check_mode(host):
     """
     Check if can check mode do nothing
     """
     # Given
     test_acl_configuration = acl_defaut_configuration.copy()
     test_acl_configuration.update({
+        'name': get_acl_name(),
         'state': 'present'
     })
     test_acl_configuration.update(sasl_default_configuration)
     ensure_kafka_acl(
-        localhost,
+        host,
         test_acl_configuration
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     check_acl_configuration = test_acl_configuration.copy()
     check_acl_configuration.update({
         'state': 'absent'
     })
     ensure_kafka_acl(
-        localhost,
+        host,
         check_acl_configuration,
         check=True
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     check_acl_configuration.update({
         'state': 'present',
         'name': "test_" + str(time.time())
     })
     ensure_kafka_acl(
-        localhost,
+        host,
         check_acl_configuration,
         check=True
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
     for host, host_vars in kafka_hosts.items():
         kfk_sasl_addr = "%s:9094" % \

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -9,6 +9,7 @@ import time
 import testinfra.utils.ansible_runner
 from tests.ansible_utils import (
     get_topic_name,
+    get_acl_name,
     get_consumer_group,
     topic_defaut_configuration,
     acl_defaut_configuration,
@@ -25,13 +26,7 @@ from tests.ansible_utils import (
 
 runner = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE'])
-testinfra_hosts = runner.get_hosts('kafka')
-
-localhost = testinfra.get_host(
-    'localhost',
-    connection='ansible',
-    ansible_inventory=os.environ['MOLECULE_INVENTORY_FILE']
-)
+testinfra_hosts = runner.get_hosts('executors')
 
 kafka_hosts = dict()
 for host in testinfra.get_hosts(
@@ -42,18 +37,18 @@ for host in testinfra.get_hosts(
     kafka_hosts[host] = host.ansible.get_variables()
 
 
-def test_update_replica_factor():
+def test_update_replica_factor(host):
     """
     Check if can update replication factor
     """
     # Given
     topic_name = get_topic_name()
     ensure_topic(
-        localhost,
+        host,
         topic_defaut_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     test_topic_configuration = topic_defaut_configuration.copy()
     test_topic_configuration.update({
@@ -61,31 +56,31 @@ def test_update_replica_factor():
     })
     ensure_idempotency(
         ensure_topic,
-        localhost,
+        host,
         test_topic_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
-    for host, host_vars in kafka_hosts.items():
+    for kafka_host, host_vars in kafka_hosts.items():
         kfk_addr = "%s:9092" % \
             host_vars['ansible_eth0']['ipv4']['address']['__ansible_unsafe']
-        check_configured_topic(host, test_topic_configuration,
+        check_configured_topic(kafka_host, test_topic_configuration,
                                topic_name, kfk_addr)
 
 
-def test_update_partitions():
+def test_update_partitions(host):
     """
     Check if can update partitions numbers
     """
     # Given
     topic_name = get_topic_name()
     ensure_topic(
-        localhost,
+        host,
         topic_defaut_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     test_topic_configuration = topic_defaut_configuration.copy()
     test_topic_configuration.update({
@@ -93,31 +88,31 @@ def test_update_partitions():
     })
     ensure_idempotency(
         ensure_topic,
-        localhost,
+        host,
         test_topic_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
-    for host, host_vars in kafka_hosts.items():
+    for kafka_host, host_vars in kafka_hosts.items():
         kfk_addr = "%s:9092" % \
             host_vars['ansible_eth0']['ipv4']['address']['__ansible_unsafe']
-        check_configured_topic(host, test_topic_configuration,
+        check_configured_topic(kafka_host, test_topic_configuration,
                                topic_name, kfk_addr)
 
 
-def test_update_partitions_and_replica_factor():
+def test_update_partitions_and_replica_factor(host):
     """
     Check if can update partitions numbers and replica factor
     """
     # Given
     topic_name = get_topic_name()
     ensure_topic(
-        localhost,
+        host,
         topic_defaut_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     test_topic_configuration = topic_defaut_configuration.copy()
     test_topic_configuration.update({
@@ -126,20 +121,20 @@ def test_update_partitions_and_replica_factor():
     })
     ensure_idempotency(
         ensure_topic,
-        localhost,
+        host,
         test_topic_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
-    for host, host_vars in kafka_hosts.items():
+    for kafka_host, host_vars in kafka_hosts.items():
         kfk_addr = "%s:9092" % \
             host_vars['ansible_eth0']['ipv4']['address']['__ansible_unsafe']
-        check_configured_topic(host, test_topic_configuration,
+        check_configured_topic(kafka_host, test_topic_configuration,
                                topic_name, kfk_addr)
 
 
-def test_update_partitions_and_replica_factor_default_value():
+def test_update_partitions_and_replica_factor_default_value(host):
     """
     Check if can update partitions numbers
     make sure -1 values are considered, but warning + step is skipped
@@ -147,11 +142,11 @@ def test_update_partitions_and_replica_factor_default_value():
     # Given
     topic_name = get_topic_name()
     ensure_topic(
-        localhost,
+        host,
         topic_defaut_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     test_topic_configuration = topic_defaut_configuration.copy()
     test_topic_configuration.update({
@@ -159,36 +154,36 @@ def test_update_partitions_and_replica_factor_default_value():
         'replica_factor': -1
     })
     ensure_topic(
-        localhost,
+        host,
         test_topic_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
     expected_topic_configuration = topic_defaut_configuration.copy()
     expected_topic_configuration.update({
         'partitions': 1,
         'replica_factor': 1
     })
-    for host, host_vars in kafka_hosts.items():
+    for kafka_host, host_vars in kafka_hosts.items():
         kfk_addr = "%s:9092" % \
             host_vars['ansible_eth0']['ipv4']['address']['__ansible_unsafe']
-        check_configured_topic(host, expected_topic_configuration,
+        check_configured_topic(kafka_host, expected_topic_configuration,
                                topic_name, kfk_addr)
 
 
-def test_add_options():
+def test_add_options(host):
     """
     Check if can update topic options
     """
     # Given
     topic_name = get_topic_name()
     ensure_topic(
-        localhost,
+        host,
         topic_defaut_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     test_topic_configuration = topic_defaut_configuration.copy()
     test_topic_configuration.update({
@@ -199,20 +194,20 @@ def test_add_options():
     })
     ensure_idempotency(
         ensure_topic,
-        localhost,
+        host,
         test_topic_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
-    for host, host_vars in kafka_hosts.items():
+    for kafka_host, host_vars in kafka_hosts.items():
         kfk_addr = "%s:9092" % \
             host_vars['ansible_eth0']['ipv4']['address']['__ansible_unsafe']
-        check_configured_topic(host, test_topic_configuration,
+        check_configured_topic(kafka_host, test_topic_configuration,
                                topic_name, kfk_addr)
 
 
-def test_delete_options():
+def test_delete_options(host):
     """
     Check if can remove topic options
     """
@@ -226,11 +221,11 @@ def test_delete_options():
     })
     topic_name = get_topic_name()
     ensure_topic(
-        localhost,
+        host,
         init_topic_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     test_topic_configuration = topic_defaut_configuration.copy()
     test_topic_configuration.update({
@@ -240,35 +235,35 @@ def test_delete_options():
     })
     ensure_idempotency(
         ensure_topic,
-        localhost,
+        host,
         test_topic_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
     deleted_options = {
         'retention.ms': 66574936,
     }
-    for host, host_vars in kafka_hosts.items():
+    for kafka_host, host_vars in kafka_hosts.items():
         kfk_addr = "%s:9092" % \
             host_vars['ansible_eth0']['ipv4']['address']['__ansible_unsafe']
-        check_configured_topic(host, test_topic_configuration,
+        check_configured_topic(kafka_host, test_topic_configuration,
                                topic_name, kfk_addr,
                                deleted_options=deleted_options)
 
 
-def test_delete_topic():
+def test_delete_topic(host):
     """
     Check if can delete topic
     """
     # Given
     topic_name = get_topic_name()
     ensure_topic(
-        localhost,
+        host,
         topic_defaut_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     test_topic_configuration = topic_defaut_configuration.copy()
     test_topic_configuration.update({
@@ -276,145 +271,148 @@ def test_delete_topic():
     })
     ensure_idempotency(
         ensure_topic,
-        localhost,
+        host,
         test_topic_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
-    for host, host_vars in kafka_hosts.items():
+    for kafka_host, host_vars in kafka_hosts.items():
         kfk_addr = "%s:9092" % \
             host_vars['ansible_eth0']['ipv4']['address']['__ansible_unsafe']
-        check_configured_topic(host, test_topic_configuration,
+        check_configured_topic(kafka_host, test_topic_configuration,
                                topic_name, kfk_addr)
 
 
-def test_acl_create():
+def test_acl_create(host):
     """
     Check if can create acls
     """
     # Given
     test_acl_configuration = acl_defaut_configuration.copy()
     test_acl_configuration.update({
+        'name': get_acl_name(),
         'state': 'absent',
         **sasl_default_configuration
     })
     ensure_acl(
-        localhost,
+        host,
         test_acl_configuration
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     test_acl_configuration.update({
         'state': 'present'
     })
     ensure_idempotency(
         ensure_acl,
-        localhost,
+        host,
         test_acl_configuration
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
-    for host, host_vars in kafka_hosts.items():
+    for kafka_host, host_vars in kafka_hosts.items():
         kfk_addr = "%s:9094" % \
             host_vars['ansible_eth0']['ipv4']['address']['__ansible_unsafe']
-        check_configured_acl(host, test_acl_configuration, kfk_addr)
+        check_configured_acl(kafka_host, test_acl_configuration, kfk_addr)
 
 
-def test_acl_delete():
+def test_acl_delete(host):
     """
     Check if can delete acls
     """
     # Given
     test_acl_configuration = acl_defaut_configuration.copy()
     test_acl_configuration.update({
+        'name': get_acl_name(),
         'state': 'present',
         **sasl_default_configuration
     })
     ensure_acl(
-        localhost,
+        host,
         test_acl_configuration
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     test_acl_configuration.update({
         'state': 'absent'
     })
     ensure_idempotency(
         ensure_acl,
-        localhost,
+        host,
         test_acl_configuration
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
-    for host, host_vars in kafka_hosts.items():
+    for kafka_host, host_vars in kafka_hosts.items():
         kfk_addr = "%s:9094" % \
             host_vars['ansible_eth0']['ipv4']['address']['__ansible_unsafe']
-        check_configured_acl(host, test_acl_configuration, kfk_addr)
+        check_configured_acl(kafka_host, test_acl_configuration, kfk_addr)
 
 
-def test_consumer_lag():
+def test_consumer_lag(host):
     """
     Check if can check global consumer lag
     """
     # Given
     topic_name = get_topic_name()
     ensure_topic(
-        localhost,
+        host,
         topic_defaut_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     consumer_group = get_consumer_group()
     total_msg = 42
     # When
     produce_and_consume_topic(
         topic_name, total_msg, consumer_group)
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
-    for host, host_vars in kafka_hosts.items():
-        lag = call_kafka_stat_lag(localhost, {
-            'consummer_group': consumer_group
-        })
-        msg = json.loads(lag[0]['msg'])
+    lags = call_kafka_stat_lag(host, {
+        'consummer_group': consumer_group
+    })
+    for lag in lags:
+        msg = json.loads(lag['msg'])
         global_lag_count = msg['global_lag_count']
         assert global_lag_count == (total_msg - 1)
 
 
-def test_check_mode():
+def test_check_mode(host):
     """
     Check if can check mode do nothing
     """
     # Given
     topic_name = get_topic_name()
     ensure_topic(
-        localhost,
+        host,
         topic_defaut_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     test_acl_configuration = acl_defaut_configuration.copy()
     test_acl_configuration.update({
+        'name': get_acl_name(),
         'state': 'present',
         **sasl_default_configuration
     })
     ensure_acl(
-        localhost,
+        host,
         test_acl_configuration
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     test_topic_configuration = topic_defaut_configuration.copy()
     test_topic_configuration.update({
         'state': 'absent'
     })
     ensure_topic(
-        localhost,
+        host,
         test_topic_configuration,
         topic_name,
         check=True
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     test_topic_configuration.update({
         'state': 'present',
         'partitions': topic_defaut_configuration['partitions'] + 1,
@@ -424,76 +422,76 @@ def test_check_mode():
         }
     })
     ensure_topic(
-        localhost,
+        host,
         test_topic_configuration,
         topic_name,
         check=True
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     new_topic_name = get_topic_name()
     ensure_topic(
-        localhost,
+        host,
         test_topic_configuration,
         new_topic_name,
         check=True
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     check_acl_configuration = test_acl_configuration.copy()
     check_acl_configuration.update({
         'state': 'absent'
     })
     ensure_acl(
-        localhost,
+        host,
         check_acl_configuration,
         check=True
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     check_acl_configuration.update({
         'state': 'present',
         'name': get_topic_name()
     })
     ensure_acl(
-        localhost,
+        host,
         check_acl_configuration,
         check=True
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
     expected_topic_configuration = topic_defaut_configuration.copy()
-    for host, host_vars in kafka_hosts.items():
+    for kafka_host, host_vars in kafka_hosts.items():
         kfk_addr = "%s:9092" % \
             host_vars['ansible_eth0']['ipv4']['address']['__ansible_unsafe']
         kfk_sasl_addr = "%s:9094" % \
             host_vars['ansible_eth0']['ipv4']['address']['__ansible_unsafe']
-        check_configured_topic(host, expected_topic_configuration,
+        check_configured_topic(kafka_host, expected_topic_configuration,
                                topic_name, kfk_addr)
-        check_configured_acl(host, test_acl_configuration, kfk_sasl_addr)
+        check_configured_acl(kafka_host, test_acl_configuration, kfk_sasl_addr)
         test_topic_configuration.update({
             'state': 'absent'
         })
-        check_configured_topic(host, test_topic_configuration,
+        check_configured_topic(kafka_host, test_topic_configuration,
                                new_topic_name, kfk_addr)
         check_acl_configuration.update({
             'state': 'absent'
         })
-        check_configured_acl(host, test_acl_configuration, kfk_sasl_addr)
+        check_configured_acl(kafka_host, test_acl_configuration, kfk_sasl_addr)
 
 
-def test_kafka_info_topic():
+def test_kafka_info_topic(host):
     """
     Check if can get info on topic
     """
     # Given
     topic_name = get_topic_name()
     ensure_topic(
-        localhost,
+        host,
         topic_defaut_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     results = call_kafka_info(
-        localhost,
+        host,
         {
             'resource': 'topic'
         }
@@ -503,21 +501,21 @@ def test_kafka_info_topic():
         assert topic_name in r['ansible_module_results']
 
 
-def test_kafka_info_brokers():
+def test_kafka_info_brokers(host):
     """
     Check if can get info on brokers
     """
     # Given
     topic_name = get_topic_name()
     ensure_topic(
-        localhost,
+        host,
         topic_defaut_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     results = call_kafka_info(
-        localhost,
+        host,
         {
             'resource': 'broker'
         }
@@ -527,27 +525,27 @@ def test_kafka_info_brokers():
         assert len(r['ansible_module_results']) == 2
 
 
-def test_kafka_info_consumer_group():
+def test_kafka_info_consumer_group(host):
     """
     Check if can get info on consumer groups
     """
     # Given
     topic_name = get_topic_name()
     ensure_topic(
-        localhost,
+        host,
         topic_defaut_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     consumer_group = get_consumer_group()
     total_msg = 42
     # When
     produce_and_consume_topic(
         topic_name, total_msg, consumer_group)
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
     results = call_kafka_info(
-        localhost,
+        host,
         {
             'resource': 'consumer_group'
         }

--- a/molecule/default/tests/test_topic_default.py
+++ b/molecule/default/tests/test_topic_default.py
@@ -18,13 +18,7 @@ from tests.ansible_utils import (
 
 runner = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE'])
-testinfra_hosts = runner.get_hosts('kafka')
-
-localhost = testinfra.get_host(
-    'localhost',
-    connection='ansible',
-    ansible_inventory=os.environ['MOLECULE_INVENTORY_FILE']
-)
+testinfra_hosts = runner.get_hosts('executors')
 
 kafka_hosts = dict()
 for host in testinfra.get_hosts(
@@ -35,18 +29,18 @@ for host in testinfra.get_hosts(
     kafka_hosts[host] = host.ansible.get_variables()
 
 
-def test_update_replica_factor():
+def test_update_replica_factor(host):
     """
     Check if can update replication factor
     """
     # Given
     topic_name = get_topic_name()
     ensure_kafka_topic(
-        localhost,
+        host,
         topic_defaut_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     test_topic_configuration = topic_defaut_configuration.copy()
     test_topic_configuration.update({
@@ -54,11 +48,11 @@ def test_update_replica_factor():
     })
     ensure_idempotency(
         ensure_kafka_topic_with_zk,
-        localhost,
+        host,
         test_topic_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
     for host, host_vars in kafka_hosts.items():
         kfk_addr = "%s:9092" % \
@@ -67,18 +61,18 @@ def test_update_replica_factor():
                                topic_name, kfk_addr)
 
 
-def test_update_partitions():
+def test_update_partitions(host):
     """
     Check if can update partitions numbers
     """
     # Given
     topic_name = get_topic_name()
     ensure_kafka_topic(
-        localhost,
+        host,
         topic_defaut_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     test_topic_configuration = topic_defaut_configuration.copy()
     test_topic_configuration.update({
@@ -86,11 +80,11 @@ def test_update_partitions():
     })
     ensure_idempotency(
         ensure_kafka_topic_with_zk,
-        localhost,
+        host,
         test_topic_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
     for host, host_vars in kafka_hosts.items():
         kfk_addr = "%s:9092" % \
@@ -99,18 +93,18 @@ def test_update_partitions():
                                topic_name, kfk_addr)
 
 
-def test_update_partitions_without_zk():
+def test_update_partitions_without_zk(host):
     """
     Check if can update partitions numbers without zk (only > 1.0.0)
     """
     # Given
     topic_name = get_topic_name()
     ensure_kafka_topic(
-        localhost,
+        host,
         topic_defaut_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     test_topic_configuration = topic_defaut_configuration.copy()
     test_topic_configuration.update({
@@ -118,12 +112,12 @@ def test_update_partitions_without_zk():
     })
     ensure_idempotency(
         ensure_kafka_topic,
-        localhost,
+        host,
         test_topic_configuration,
         topic_name,
         minimal_api_version="1.0.0"
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
     for host, host_vars in kafka_hosts.items():
         if (parse_version(
@@ -136,18 +130,18 @@ def test_update_partitions_without_zk():
                                topic_name, kfk_addr)
 
 
-def test_update_partitions_and_replica_factor():
+def test_update_partitions_and_replica_factor(host):
     """
     Check if can update partitions numbers and replica factor
     """
     # Given
     topic_name = get_topic_name()
     ensure_kafka_topic(
-        localhost,
+        host,
         topic_defaut_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     test_topic_configuration = topic_defaut_configuration.copy()
     test_topic_configuration.update({
@@ -156,11 +150,11 @@ def test_update_partitions_and_replica_factor():
     })
     ensure_idempotency(
         ensure_kafka_topic_with_zk,
-        localhost,
+        host,
         test_topic_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
     for host, host_vars in kafka_hosts.items():
         kfk_addr = "%s:9092" % \
@@ -169,7 +163,7 @@ def test_update_partitions_and_replica_factor():
                                topic_name, kfk_addr)
 
 
-def test_update_partitions_and_replica_factor_default_value():
+def test_update_partitions_and_replica_factor_default_value(host):
     """
     Check if can update partitions numbers
     make sure -1 values are considered, but warning + step is skipped
@@ -177,11 +171,11 @@ def test_update_partitions_and_replica_factor_default_value():
     # Given
     topic_name = get_topic_name()
     ensure_kafka_topic(
-        localhost,
+        host,
         topic_defaut_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     test_topic_configuration = topic_defaut_configuration.copy()
     test_topic_configuration.update({
@@ -189,11 +183,11 @@ def test_update_partitions_and_replica_factor_default_value():
         'replica_factor': -1
     })
     ensure_kafka_topic(
-        localhost,
+        host,
         test_topic_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
     expected_topic_configuration = topic_defaut_configuration.copy()
     expected_topic_configuration.update({
@@ -207,18 +201,18 @@ def test_update_partitions_and_replica_factor_default_value():
                                topic_name, kfk_addr)
 
 
-def test_add_options():
+def test_add_options(host):
     """
     Check if can update topic options
     """
     # Given
     topic_name = get_topic_name()
     ensure_kafka_topic(
-        localhost,
+        host,
         topic_defaut_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     test_topic_configuration = topic_defaut_configuration.copy()
     test_topic_configuration.update({
@@ -229,11 +223,11 @@ def test_add_options():
     })
     ensure_idempotency(
         ensure_kafka_topic,
-        localhost,
+        host,
         test_topic_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
     for host, host_vars in kafka_hosts.items():
         kfk_addr = "%s:9092" % \
@@ -242,7 +236,7 @@ def test_add_options():
                                topic_name, kfk_addr)
 
 
-def test_delete_options():
+def test_delete_options(host):
     """
     Check if can remove topic options
     """
@@ -256,11 +250,11 @@ def test_delete_options():
     })
     topic_name = get_topic_name()
     ensure_kafka_topic(
-        localhost,
+        host,
         init_topic_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     test_topic_configuration = topic_defaut_configuration.copy()
     test_topic_configuration.update({
@@ -270,11 +264,11 @@ def test_delete_options():
     })
     ensure_idempotency(
         ensure_kafka_topic,
-        localhost,
+        host,
         test_topic_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
     deleted_options = {
         'retention.ms': 66574936,
@@ -287,18 +281,18 @@ def test_delete_options():
                                deleted_options=deleted_options)
 
 
-def test_delete_topic():
+def test_delete_topic(host):
     """
     Check if can delete topic
     """
     # Given
     topic_name = get_topic_name()
     ensure_kafka_topic(
-        localhost,
+        host,
         topic_defaut_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     test_topic_configuration = topic_defaut_configuration.copy()
     test_topic_configuration.update({
@@ -306,11 +300,11 @@ def test_delete_topic():
     })
     ensure_idempotency(
         ensure_kafka_topic,
-        localhost,
+        host,
         test_topic_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
     for host, host_vars in kafka_hosts.items():
         kfk_addr = "%s:9092" % \
@@ -319,30 +313,30 @@ def test_delete_topic():
                                topic_name, kfk_addr)
 
 
-def test_check_mode():
+def test_check_mode(host):
     """
     Check if can check mode do nothing
     """
     # Given
     topic_name = get_topic_name()
     ensure_kafka_topic(
-        localhost,
+        host,
         topic_defaut_configuration,
         topic_name
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # When
     test_topic_configuration = topic_defaut_configuration.copy()
     test_topic_configuration.update({
         'state': 'absent'
     })
     ensure_kafka_topic_with_zk(
-        localhost,
+        host,
         test_topic_configuration,
         topic_name,
         check=True
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     test_topic_configuration.update({
         'state': 'present',
         'partitions': topic_defaut_configuration['partitions'] + 1,
@@ -352,20 +346,20 @@ def test_check_mode():
         }
     })
     ensure_kafka_topic_with_zk(
-        localhost,
+        host,
         test_topic_configuration,
         topic_name,
         check=True
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     new_topic_name = get_topic_name()
     ensure_kafka_topic_with_zk(
-        localhost,
+        host,
         test_topic_configuration,
         new_topic_name,
         check=True
     )
-    time.sleep(0.5)
+    time.sleep(0.3)
     # Then
     expected_topic_configuration = topic_defaut_configuration.copy()
     for host, host_vars in kafka_hosts.items():

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,4 +4,6 @@ funcsigs
 molecule==3.2.2
 molecule-docker==0.3.3
 pytest-testinfra==6.1.0
+pytest-xdist==2.2.1
+pytest-instafail==0.4.2
 flake8


### PR DESCRIPTION
## Proposed Changes

  - Dissociate python version from test tools & tested version.
  - Add python 3.5 to test suite. 
  - Reactivate support for python2.
  - Add python-xdist for testing
  - Add python-instafail to see fail before testing end
  - Make molecule verbose to see live testing
  - Make all test independent
