### PR TITLE
Add kafka_quotas module

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ If you want to increase partitions, replication factor, change your topic's para
 * kafka_topics: Manage more than one topic in bulk mode
 * kafka_acl: Manage kafka acl
 * kafka_acls: Manage more than one acl in bulk mode
+* kafka_quotas: Manage quotas on user or client-id
 * kafka_info: Get infos on kafka resources
 * kafka_stat_lag: get lag info on topics / consumer groups
 ## Requirements
@@ -35,6 +36,7 @@ Add the following requirement in your playbook's **requirements.yml**:
 **Note**:
 Zookeeper is only needed when:
 * replication-factor changed with Kafka < 2.4.0
+* using kafka_quotas with Kafka < 2.6.0
 * Kafka <= 0.11.0
 
 See the [`examples`](examples) folder for real-life examples.
@@ -229,6 +231,26 @@ Here some examples on how to use this library:
     acl_operation: 'write'
     acl_permission: 'allow'
     state: 'absent'
+    bootstrap_servers: "{{ hostvars['kafka1']['ansible_eth0']['ipv4']['address'] }}:9092,{{ hostvars['kafka2']['ansible_eth0']['ipv4']['address'] }}:9092"
+
+# Ensure Quota present for users `test` and `test2`
+- name: Ensure quota for user test and test2
+  kafka_quotas:
+    entries:
+    - entity:
+      - entity_type: user
+        entity_name: test
+      quotas:
+        producer_byte_rate: 104405
+        consumer_byte_rate: 104405
+        request_percentage: 55
+    - entity:
+      - entity_type: user
+        entity_name: test2
+      quotas:
+        producer_byte_rate: 1044050
+        consumer_byte_rate: 1044050
+        request_percentage: 65
     bootstrap_servers: "{{ hostvars['kafka1']['ansible_eth0']['ipv4']['address'] }}:9092,{{ hostvars['kafka2']['ansible_eth0']['ipv4']['address'] }}:9092"
 
 

--- a/library/kafka_quotas.py
+++ b/library/kafka_quotas.py
@@ -1,0 +1,170 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""
+Ansible module for akfka quotas management
+"""
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+# Init logging
+import logging
+import sys
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible.module_utils.kafka_lib_quotas import process_module_quotas
+
+from ansible.module_utils.kafka_lib_commons import (
+    module_commons, module_zookeeper_commons,
+    DOCUMENTATION_COMMON
+)
+# Default logging
+# TODO: refactor all this logging logic
+log = logging.getLogger('kafka')
+log.addHandler(logging.StreamHandler(sys.stdout))
+log.setLevel(logging.INFO)
+
+ANSIBLE_METADATA = {'metadata_version': '1.0'}
+
+
+DOCUMENTATION = '''
+---
+module: kafka_quotas
+short_description: Manage Kafka quotas
+description:
+     - Configure Kafka quotas.
+     - Not compatible avec Kafka version < 0.11.0.
+author:
+    - Stephen SORRIAUX
+    - ryarnyah
+options:
+  entries:
+    description:
+      - Entries to manage.
+  mark_others_as_absent:
+    description:
+      - make non listed topics as absent, thus triggering the deletion
+      - of topics absent from the `topics` listing
+  zookeeper:
+    description:
+      - 'the zookeeper connection.'
+  zookeeper_auth_scheme:
+    description:
+      - 'when zookeeper is configured to use authentication, schema used to '
+      - 'connect to zookeeper.'
+      default: 'digest'
+      choices: [digest, sasl]
+  zookeeper_auth_value:
+    description:
+      - 'when zookeeper is configured to use authentication, value used to '
+      - 'connect.'
+  zookeeper_ssl_check_hostname:
+    description:
+      - 'when using ssl for zookeeper, check if certificate for hostname is '
+      - 'correct.'
+    default: True
+  zookeeper_ssl_cafile:
+    description:
+      - 'when using ssl for zookeeper, content of ca cert file or path to '
+      - 'ca cert file.'
+  zookeeper_ssl_certfile:
+    description:
+      - 'when using ssl for zookeeper, content of cert file or path to '
+      - 'server cert file.'
+  zookeeper_ssl_keyfile:
+    description:
+      - 'when using ssl for zookeeper, content of keyfile or path to '
+      - 'server cert key file.'
+  zookeeper_ssl_password:
+    description:
+      - 'when using ssl for zookeeper, password for ssl_keyfile.'
+  zookeeper_sleep_time:
+    description:
+      - 'when updating number of partitions and while checking for'
+      - 'the ZK node, the time to sleep (in seconds) between'
+      - 'each checks.'
+      default: 5
+  zookeeper_max_retries:
+    description:
+      - 'when updating number of partitions and while checking for'
+      - 'the ZK node, maximum of try to do before failing'
+      default: 5
+  kafka_sleep_time:
+    description:
+      - 'when updating number of partitions and while checking for'
+      - 'kafka to applied, the time to sleep (in seconds) between'
+      - 'each checks.'
+      default: 5
+  kafka_max_retries:
+    description:
+      - 'when updating number of partitions and while checking for'
+      - 'kafka to applied, maximum of try to do before failing'
+      default: 5
+''' + DOCUMENTATION_COMMON
+
+EXAMPLES = '''
+
+    # add quotas
+    - name: create quotas
+      kafka_quotas:
+        entries:
+        - entity:
+          - entity_type: user
+            entity_name: test
+          quotas:
+            producer_byte_rate: 1048576
+            consumer_byte_rate: 1048576
+            request_percentage: 55
+        zookeeper: >
+          "{{ hostvars['zk']['ansible_eth0']['ipv4']['address'] }}:2181"
+        bootstrap_servers: >
+          "{{ hostvars['kafka1']['ansible_eth0']['ipv4']['address'] }}:9092,
+          {{ hostvars['kafka2']['ansible_eth0']['ipv4']['address'] }}:9092"
+'''
+
+
+def main():
+    """
+    Module usage
+    """
+    spec = dict(
+        entries=dict(
+            type='list',
+            elements='dict',
+            required=True,
+            options=dict(
+                entity=dict(
+                    type='list',
+                    required=True,
+                    elements='dict',
+                    options=dict(
+                        entity_type=dict(type='str',
+                                         choice=['user', 'client-id'],
+                                         required=True),
+                        entity_name=dict(type='str', required=True)
+                    )
+                ),
+                quotas=dict(
+                    type='dict',
+                    required=True,
+                    options=dict(
+                        producer_byte_rate=dict(type='int'),
+                        consumer_byte_rate=dict(type='int'),
+                        request_percentage=dict(type='float')
+                    ))
+            )
+        ),
+        **module_commons
+    )
+    spec.update(module_zookeeper_commons)
+
+    module = AnsibleModule(
+        argument_spec=spec,
+        supports_check_mode=True
+    )
+
+    process_module_quotas(module)
+
+
+if __name__ == '__main__':
+    main()

--- a/module_utils/kafka_lib_quotas.py
+++ b/module_utils/kafka_lib_quotas.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+from kafka.errors import KafkaError
+
+from ansible.module_utils.pycompat24 import get_exception
+
+from ansible.module_utils.kafka_lib_commons import (
+    get_manager_from_params,
+    maybe_clean_kafka_ssl_files,
+    maybe_clean_zk_ssl_files
+)
+
+
+def process_module_quotas(module, params=None):
+    params = params if params is not None else module.params
+
+    entries = params['entries']
+
+    changed = False
+    msg = ''
+    changes = dict()
+
+    manager = None
+    try:
+        manager = get_manager_from_params(params)
+        current_entries = manager.describe_quotas()
+
+        alter_entries = []
+        for entry in entries:
+            found = False
+            entry_quotas = {key: value for key, value
+                            in entry['quotas'].items() if value is not None}
+            for current_entry in current_entries:
+                if current_entry['entity'] == entry['entity']:
+                    found = True
+                    if current_entry['quotas'] != entry_quotas:
+                        keys_to_add = {key: value for key, value in
+                                       entry_quotas.items() if
+                                       key not in current_entry['quotas']}
+                        keys_to_delete = {key: value for key, value in
+                                          current_entry['quotas'].items() if
+                                          key not in entry_quotas}
+                        keys_to_alter = {key: value for key, value in
+                                         entry_quotas.items() if
+                                         key in current_entry['quotas'] and
+                                         current_entry['quotas'][key] != value}
+                        alter_entries.append({
+                            'entity': entry['entity'],
+                            'quotas_to_add': keys_to_add,
+                            'quotas_to_alter': keys_to_alter,
+                            'quotas_to_delete': keys_to_delete
+                        })
+            if not found and len(entry_quotas) > 0:
+                alter_entries.append({
+                    'entity': entry['entity'],
+                    'quotas_to_add': entry_quotas,
+                    'quotas_to_delete': dict(),
+                    'quotas_to_alter': dict()
+                })
+        if len(alter_entries) > 0:
+            if not module.check_mode:
+                manager.alter_quotas(alter_entries)
+            changed = True
+            msg = 'entries altered'
+            changes = alter_entries
+    except KafkaError:
+        e = get_exception()
+        module.fail_json(
+            msg='Unable to initialize Kafka manager: %s' % e
+        )
+    except Exception:
+        e = get_exception()
+        module.fail_json(
+            msg='Something went wrong: %s' % e
+        )
+    finally:
+        if manager:
+            manager.close()
+        maybe_clean_kafka_ssl_files(params)
+        maybe_clean_zk_ssl_files(params)
+
+    if not changed:
+        msg += 'nothing to do.'
+
+    module.exit_json(changed=changed, msg=msg, changes=changes)

--- a/module_utils/kafka_manager.py
+++ b/module_utils/kafka_manager.py
@@ -1231,7 +1231,9 @@ and following this structure:
                                 'entity_name': client_id
                             }],
                             'quotas': {key: float(value) for key, value
-                                       in json.loads(config)['config'].items()}
+                                       in json.loads(
+                                           config.decode('ascii')
+                                       )['config'].items()}
                         })
                 # Get users quotas
                 if self.zk_client.exists(zknode + '/users'):
@@ -1246,7 +1248,9 @@ and following this structure:
                                 'entity_name': user
                             }],
                             'quotas': {key: float(value) for key, value
-                                       in json.loads(config)['config'].items()}
+                                       in json.loads(
+                                           config.decode('ascii')
+                                       )['config'].items()}
                         })
                         if self.zk_client.exists(zknode + '/users/'
                                                  + user + '/clients'):
@@ -1269,7 +1273,8 @@ and following this structure:
                                     'quotas': {key: float(value) for
                                                key, value in
                                                json.loads(
-                                                   config)['config'].items()}
+                                                   config.decode('ascii')
+                                               )['config'].items()}
                                 })
                 return current_quotas
             finally:
@@ -1299,7 +1304,7 @@ and following this structure:
                         znode += '/clients/' + entity_description['client-id']
                     if self.zk_client.exists(znode):
                         node, _ = self.zk_client.get(znode)
-                        existing_node = json.loads(node)
+                        existing_node = json.loads(node.decode('ascii'))
                         existing_node['config'].update(
                             quota['quotas_to_add'])
                         existing_node['config'].update(

--- a/module_utils/kafka_protocol.py
+++ b/module_utils/kafka_protocol.py
@@ -3,7 +3,90 @@ from kafka.protocol.struct import Struct
 from kafka.protocol.types import (Boolean,
                                   Int8,
                                   Int16,
-                                  Int32, String, Schema, Array)
+                                  Int32, String, Schema, Array, _pack, _unpack)
+from kafka.protocol import API_KEYS
+import struct
+from kafka.protocol.abstract import AbstractType
+
+
+# Quotas
+class Float64(AbstractType):
+    _pack = struct.Struct('>d').pack
+    _unpack = struct.Struct('>d').unpack
+
+    @classmethod
+    def encode(cls, value):
+        return _pack(cls._pack, value)
+
+    @classmethod
+    def decode(cls, data):
+        return _unpack(cls._unpack, data.read(8))
+
+
+class DescribeClientQuotasResponse_v0(Response):
+    API_KEY = 48
+    API_VERSION = 0
+    SCHEMA = Schema(
+        ('throttle_time_ms', Int32),
+        ('error_code', Int16),
+        ('error_message', String('utf-8')),
+        ('entries', Array(
+            ('entity', Array(
+                ('entity_type', String('utf-8')),
+                ('entity_name', String('utf-8')))),
+            ('values', Array(
+                ('name', String('utf-8')),
+                ('value', Float64))))),
+    )
+
+
+class DescribeClientQuotasRequest_v0(Request):
+    API_KEY = 48
+    API_VERSION = 0
+    RESPONSE_TYPE = DescribeClientQuotasResponse_v0
+    SCHEMA = Schema(
+        ('components', Array(
+            ('entity_type', String('utf-8')),
+            ('match_type', Int8),
+            ('match', String('utf-8')),
+        )),
+        ('strict', Boolean)
+    )
+
+
+class AlterClientQuotasResponse_v0(Response):
+    API_KEY = 49
+    API_VERSION = 0
+    SCHEMA = Schema(
+        ('throttle_time_ms', Int32),
+        ('entries', Array(
+            ('error_code', Int16),
+            ('error_message', String('utf-8')),
+            ('entity', Array(
+                ('entity_type', String('utf-8')),
+                ('entity_name', String('utf-8'))))))
+    )
+
+
+class AlterClientQuotasRequest_v0(Request):
+    API_KEY = 49
+    API_VERSION = 0
+    RESPONSE_TYPE = AlterClientQuotasResponse_v0
+    SCHEMA = Schema(
+        ('entries', Array(
+            ('entity', Array(
+                    ('entity_type', String('utf-8')),
+                    ('entity_name', String('utf-8')))),
+            ('ops', Array(
+                    ('key', String('utf-8')),
+                    ('value', Float64),
+                    ('remove', Boolean))))),
+        ('validate_only', Boolean)
+    )
+
+
+API_KEYS[48] = 'DescribeClientQuotas'
+API_KEYS[49] = 'AlterClientQuotas'
 
 
 # Bug https://github.com/dpkp/kafka-python/pull/2206

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -157,8 +157,8 @@ platforms:
       - ${MOLECULE_SCENARIO_DIRECTORY}/kafka_server_jaas.conf:/opt/kafka/jaas/kafka_server_jaas.conf
     groups:
       - kafka
-  # 2.5.0
-  - name: zookeeper-250
+  # 2.6.0
+  - name: zookeeper-260
     image: zookeeper:3.4
     command: "bin/zkServer.sh start-foreground"
     published_ports:
@@ -166,11 +166,11 @@ platforms:
     networks:
       - name: molecule
         aliases:
-          - zookeeper-250
+          - zookeeper-260
     groups:
       - zookeeper
-  - name: kafka1-250
-    image: wurstmeister/kafka:2.12-2.5.0
+  - name: kafka1-260
+    image: wurstmeister/kafka:2.13-2.6.0
     command: "start-kafka.sh"
     env:
       HOSTNAME_COMMAND: "hostname -i | cut -d' ' -f1"
@@ -178,7 +178,7 @@ platforms:
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://_{HOSTNAME_COMMAND}:9092,SASL_PLAINTEXT://_{HOSTNAME_COMMAND}:9094
       KAFKA_LISTENERS: PLAINTEXT://:9092,SASL_PLAINTEXT://:9094
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper-250:2181
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-260:2181
       KAFKA_AUTHORIZER_CLASS_NAME: kafka.security.auth.SimpleAclAuthorizer
       KAFKA_SUPER_USERS: User:admin
       KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
@@ -190,15 +190,15 @@ platforms:
     networks:
       - name: molecule
         links:
-          - zookeeper-250
+          - zookeeper-260
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${MOLECULE_SCENARIO_DIRECTORY}/kafka_server_jaas.conf:/opt/kafka/jaas/kafka_server_jaas.conf
     groups:
       - kafka
       - kafka1
-  - name: kafka2-250
-    image: wurstmeister/kafka:2.12-2.5.0
+  - name: kafka2-260
+    image: wurstmeister/kafka:2.13-2.6.0
     command: "start-kafka.sh"
     env:
       HOSTNAME_COMMAND: "hostname -i | cut -d' ' -f1"
@@ -206,7 +206,7 @@ platforms:
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://_{HOSTNAME_COMMAND}:9092,SASL_PLAINTEXT://_{HOSTNAME_COMMAND}:9094
       KAFKA_LISTENERS: PLAINTEXT://:9092,SASL_PLAINTEXT://:9094
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper-250:2181
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-260:2181
       KAFKA_AUTHORIZER_CLASS_NAME: kafka.security.auth.SimpleAclAuthorizer
       KAFKA_SUPER_USERS: User:admin
       KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
@@ -218,7 +218,7 @@ platforms:
     networks:
       - name: molecule
         links:
-          - zookeeper-250
+          - zookeeper-260
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${MOLECULE_SCENARIO_DIRECTORY}/kafka_server_jaas.conf:/opt/kafka/jaas/kafka_server_jaas.conf
@@ -242,8 +242,8 @@ provisioner:
             instance_suffix: "01103"
           - protocol_version: "1.1.1"
             instance_suffix: "111"
-          - protocol_version: "2.5.0"
-            instance_suffix: "250"
+          - protocol_version: "2.6.0"
+            instance_suffix: "260"
         topic_defaut_configuration:
           state: 'present'
           replica_factor: 1

--- a/molecule/default/tests/test_quotas_default.py
+++ b/molecule/default/tests/test_quotas_default.py
@@ -1,0 +1,189 @@
+"""
+Main tests for library
+"""
+
+import os
+import time
+
+import testinfra.utils.ansible_runner
+from tests.ansible_utils import (
+    quotas_default_configuration,
+    sasl_default_configuration,
+    ensure_kafka_quotas, get_entity_name,
+    check_configured_quotas_kafka, ensure_idempotency,
+    check_configured_quotas_zookeeper
+)
+
+runner = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE'])
+testinfra_hosts = runner.get_hosts('executors')
+
+kafka_hosts = dict()
+for host in testinfra.get_hosts(
+    ['kafka1'],
+    connection='ansible',
+    ansible_inventory=os.environ['MOLECULE_INVENTORY_FILE']
+):
+    kafka_hosts[host] = host.ansible.get_variables()
+
+zookeeper_hosts = dict()
+for host in testinfra.get_hosts(
+    ['zookeeper'],
+    connection='ansible',
+    ansible_inventory=os.environ['MOLECULE_INVENTORY_FILE']
+):
+    zookeeper_hosts[host] = host.ansible.get_variables()
+
+
+def test_quotas_create(host):
+    """
+    Check if can create quotas
+    """
+    # Given
+    test_quotas_configuration = quotas_default_configuration.copy()
+    test_quotas_configuration.update({
+        'entries': [{
+            'entity': [{
+                'entity_type': 'client-id',
+                'entity_name': get_entity_name()
+            }],
+            'quotas': {
+                'producer_byte_rate': 104101
+            }
+        }]
+    })
+    test_quotas_configuration.update(sasl_default_configuration)
+    ensure_kafka_quotas(
+        host,
+        test_quotas_configuration
+    )
+    time.sleep(0.3)
+    # When
+    test_quotas_configuration['entries'][0].update({
+        'quotas': {
+            'producer_byte_rate': 104101,
+            'consumer_byte_rate': 104101
+        }
+    })
+    ensure_idempotency(
+        ensure_kafka_quotas,
+        host,
+        test_quotas_configuration
+    )
+    time.sleep(0.3)
+    # Then
+    for host, host_vars in kafka_hosts.items():
+        kfk_addr = "%s:9094" % \
+            host_vars['ansible_eth0']['ipv4']['address']['__ansible_unsafe']
+        check_configured_quotas_kafka(host,
+                                      test_quotas_configuration,
+                                      kfk_addr)
+    for host, host_vars in zookeeper_hosts.items():
+        zk_addr = "%s:2181" % \
+            host_vars['ansible_eth0']['ipv4']['address']['__ansible_unsafe']
+        check_configured_quotas_zookeeper(host,
+                                          test_quotas_configuration,
+                                          zk_addr)
+
+
+def test_quotas_alter(host):
+    """
+    Check if can create quotas
+    """
+    # Given
+    test_quotas_configuration = quotas_default_configuration.copy()
+    test_quotas_configuration.update({
+        'entries': [{
+            'entity': [{
+                'entity_type': 'user',
+                'entity_name': get_entity_name()
+            }],
+            'quotas': {
+                'producer_byte_rate': 10410,
+                'consumer_byte_rate': 10410
+            }
+        }]
+    })
+    test_quotas_configuration.update(sasl_default_configuration)
+    ensure_kafka_quotas(
+        host,
+        test_quotas_configuration
+    )
+    time.sleep(0.3)
+    # When
+    test_quotas_configuration['entries'][0].update({
+        'quotas': {
+            'producer_byte_rate': 12,
+            'consumer_byte_rate': 10
+        }
+    })
+    ensure_idempotency(
+        ensure_kafka_quotas,
+        host,
+        test_quotas_configuration
+    )
+    time.sleep(0.3)
+    # Then
+    for host, host_vars in kafka_hosts.items():
+        kfk_addr = "%s:9094" % \
+            host_vars['ansible_eth0']['ipv4']['address']['__ansible_unsafe']
+        check_configured_quotas_kafka(host,
+                                      test_quotas_configuration,
+                                      kfk_addr)
+    for host, host_vars in zookeeper_hosts.items():
+        zk_addr = "%s:2181" % \
+            host_vars['ansible_eth0']['ipv4']['address']['__ansible_unsafe']
+        check_configured_quotas_zookeeper(host,
+                                          test_quotas_configuration,
+                                          zk_addr)
+
+
+def test_quotas_delete(host):
+    """
+    Check if can create quotas
+    """
+    # Given
+    test_quotas_configuration = quotas_default_configuration.copy()
+    test_quotas_configuration.update({
+        'entries': [{
+            'entity': [{
+                'entity_type': 'user',
+                'entity_name': get_entity_name()
+            }],
+            'quotas': {
+                'producer_byte_rate': 104101,
+                'consumer_byte_rate': 104101
+            }
+        }]
+    })
+    test_quotas_configuration.update(sasl_default_configuration)
+    ensure_kafka_quotas(
+        host,
+        test_quotas_configuration
+    )
+    time.sleep(0.3)
+    # When
+    test_quotas_configuration['entries'][0].update({
+        'quotas': {
+            'producer_byte_rate': 104101
+        }
+    })
+    ensure_idempotency(
+        ensure_kafka_quotas,
+        host,
+        test_quotas_configuration
+    )
+    time.sleep(0.3)
+    # Then
+    for host, host_vars in kafka_hosts.items():
+        kfk_addr = "%s:9094" % \
+            host_vars['ansible_eth0']['ipv4']['address']['__ansible_unsafe']
+        check_configured_quotas_kafka(host,
+                                      test_quotas_configuration,
+                                      kfk_addr)
+    for host, host_vars in zookeeper_hosts.items():
+        zk_addr = "%s:2181" % \
+            host_vars['ansible_eth0']['ipv4']['address']['__ansible_unsafe']
+        check_configured_quotas_zookeeper(host,
+                                          test_quotas_configuration,
+                                          zk_addr)


### PR DESCRIPTION
Fixes #86

## Proposed Changes

  - Add module to manage quotas

## Example usage
```yaml
- name: Ensure quota for user test and test2
  kafka_quotas:
    entries:
    - entity:
      - entity_type: user
        entity_name: test
      quotas:
        producer_byte_rate: 104405
        consumer_byte_rate: 104405
        request_percentage: 55
    - entity:
      - entity_type: user
        entity_name: test2
      quotas:
        producer_byte_rate: 1044050
        consumer_byte_rate: 1044050
        request_percentage: 65
    bootstrap_servers: "{{ hostvars['kafka1']['ansible_eth0']['ipv4']['address'] }}:9092,{{ hostvars['kafka2']['ansible_eth0']['ipv4']['address'] }}:9092"
```