### PR TITLE
default should respect the intended type

### DIFF
--- a/module_utils/kafka_lib_commons.py
+++ b/module_utils/kafka_lib_commons.py
@@ -80,7 +80,7 @@ module_topic_commons = dict(
 
     replica_factor=dict(type='int', required=False, default=0),
 
-    options=dict(required=False, type='dict', default=None),
+    options=dict(required=False, type='dict', default={}),
 
     kafka_sleep_time=dict(type='int', required=False, default=5),
 


### PR DESCRIPTION
If no `options` are given for a `kafka_topic`, they will be initialized to `None` because of [kafka_lib_commons.py](https://github.com/StephenSorriaux/ansible-kafka-admin/blob/master/module_utils/kafka_lib_commons.py#L83). Unfortunately, this later leads to an error in [kafka_manager.py](https://github.com/StephenSorriaux/ansible-kafka-admin/blob/master/module_utils/kafka_manager.py#L140):
```
''NoneType'' object has no attribute ''items''.
```
This is due to the fact that there are now `options`, but their value is not a `dict()`. The suggested fix addresses the issue.