### PR TITLE
fix request to get full list of acls

### DIFF
--- a/module_utils/kafka_lib_acl.py
+++ b/module_utils/kafka_lib_acl.py
@@ -67,7 +67,7 @@ def process_module_acls(module, params=None):
                 pattern_type=ACLPatternType.ANY,
                 name=None,
                 principal=None,
-                host="*"
+                host=None
             )
         else:
             acl = acls[0]


### PR DESCRIPTION
Checked at kafka 2.6 only.
Issue: the `describe_acls` returns `acl_resource_found` that is limited only to subset of `host: '*'` literals, i.e. if there is an IP, this record is ignored.
This caused adding already existing ACLs (nothing too bad, but just wrong status and some extra calls) and, in case `mark_others_as_absent: True`, this causes to malfunction and skip of all records, which have an IP address.