### PR TITLE
Make sure to init the `manager` obj to None and check for its value

### DIFF
--- a/library/kafka_consumer_group.py
+++ b/library/kafka_consumer_group.py
@@ -88,6 +88,7 @@ def main():
     consumer_group = params['consumer_group']
     topics = params['topics']
     action = params['action']
+    manager = None
 
     try:
         manager = get_manager_from_params(params)

--- a/library/kafka_info.py
+++ b/library/kafka_info.py
@@ -74,6 +74,7 @@ def main():
 
     params = module.params
     resource = params['resource']
+    manager = None
 
     try:
         manager = get_manager_from_params(params)
@@ -89,7 +90,8 @@ def main():
             msg='Seomthing went wrong: %s ' % e
         )
     finally:
-        manager.close()
+        if manager:
+            manager.close()
         maybe_clean_kafka_ssl_files(params)
 
     module.exit_json(changed=True, results=results)

--- a/library/kafka_stat_lag.py
+++ b/library/kafka_stat_lag.py
@@ -76,6 +76,7 @@ def main():
     params = module.params
     consummer_group = params['consummer_group']
     ignore_empty_partition = params['ignore_empty_partition']
+    manager = None
 
     try:
         manager = get_manager_from_params(params)
@@ -92,7 +93,8 @@ def main():
             msg='Seomthing went wrong: %s ' % e
         )
     finally:
-        manager.close()
+        if manager:
+            manager.close()
         maybe_clean_kafka_ssl_files(params)
 
     # XXX: do we really need a JSON serialized value?

--- a/module_utils/kafka_lib_acl.py
+++ b/module_utils/kafka_lib_acl.py
@@ -46,6 +46,7 @@ def process_module_acls(module, params=None):
     msg = ''
     warn = None
     changes = {}
+    manager = None
 
     try:
         manager = get_manager_from_params(params)
@@ -171,7 +172,8 @@ def process_module_acls(module, params=None):
             changes=changes
         )
     finally:
-        manager.close()
+        if manager:
+            manager.close()
         maybe_clean_kafka_ssl_files(params)
         maybe_clean_zk_ssl_files(params)
 

--- a/module_utils/kafka_lib_topic.py
+++ b/module_utils/kafka_lib_topic.py
@@ -34,6 +34,7 @@ def process_module_topics(module, params=None):
     msg = ''
     warn = None
     changes = {}
+    manager = None
 
     try:
         manager = get_manager_from_params(params)
@@ -106,7 +107,8 @@ def process_module_topics(module, params=None):
             changes=changes
         )
     finally:
-        manager.close()
+        if manager:
+            manager.close()
         maybe_clean_kafka_ssl_files(params)
         maybe_clean_zk_ssl_files(params)
 


### PR DESCRIPTION
Make sure to init the `manager` obj to None and check for its value before trying to `close()` it.

Fixes https://github.com/StephenSorriaux/ansible-kafka-admin/issues/119

## Proposed Changes

  - always init manager to `None`
