### PR TITLE
Move kafka_sleep_time & kafka_max_retries to common module params to enable on all modules

### DIFF
--- a/module_utils/kafka_lib_commons.py
+++ b/module_utils/kafka_lib_commons.py
@@ -85,10 +85,6 @@ module_topic_commons = dict(
     preserve_leader=dict(type='bool', required=False, default=False),
 
     options=dict(required=False, type='dict', default={}),
-
-    kafka_sleep_time=dict(type='int', required=False, default=5),
-
-    kafka_max_retries=dict(type='int', required=False, default=5),
 )
 
 module_acl_commons = dict(
@@ -217,7 +213,11 @@ module_commons = dict(
 
     request_timeout_ms=dict(type='int', default=60000),
 
-    connections_max_idle_ms=dict(type='int', default=540000)
+    connections_max_idle_ms=dict(type='int', default=540000),
+
+    kafka_sleep_time=dict(type='int', required=False, default=5),
+
+    kafka_max_retries=dict(type='int', required=False, default=5)
 )
 
 

--- a/molecule/default/tests/test_topic_default.py
+++ b/molecule/default/tests/test_topic_default.py
@@ -110,6 +110,8 @@ def test_update_replica_factor_force_reassign(host):
     # When
     test_topic_configuration = topic_defaut_configuration.copy()
     test_topic_configuration.update({
+        'kafka_sleep_time': 10,
+        'kafka_max_retries': 10,
         'replica_factor': 2,
         'force_reassign': True,
         'preserve_leader': True


### PR DESCRIPTION
Fixes: Actually only kafka_topic module can use kafka_sleep_time & kafka_max_retries

## Proposed Changes

  - Enable params for all modules
