### PR TITLE
Feature/multiple acl operations

### DIFF
--- a/examples/acl-creation-multiops/docker-compose.yml
+++ b/examples/acl-creation-multiops/docker-compose.yml
@@ -1,0 +1,27 @@
+---
+version: '2'
+services:
+  zookeeper:
+    image: zookeeper:3.6
+    command: "bin/zkServer.sh start-foreground"
+    network_mode: "host"
+    container_name: zookeeper
+  kafka:
+    image: wurstmeister/kafka:2.13-2.6.0
+    command: "start-kafka.sh"
+    container_name: kafka
+    network_mode: "host"
+    environment:
+      KAFKA_DELETE_TOPIC_ENABLE: "true"
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_LISTENERS: PLAINTEXT://:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+      KAFKA_AUTHORIZER_CLASS_NAME: kafka.security.auth.SimpleAclAuthorizer
+      KAFKA_SUPER_USERS: User:admin
+      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
+      KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND: "true"
+      KAFKA_OPTS: -Djava.security.auth.login.config=/opt/kafka/jaas/kafka_server_jaas.conf
+    volumes:
+      - ./kafka_server_jaas.conf:/opt/kafka/jaas/kafka_server_jaas.conf

--- a/examples/acl-creation-multiops/kafka_server_jaas.conf
+++ b/examples/acl-creation-multiops/kafka_server_jaas.conf
@@ -1,0 +1,7 @@
+KafkaServer {
+    org.apache.kafka.common.security.plain.PlainLoginModule required
+    username="admin"
+    password="admin-secret"
+    user_admin="admin-secret"
+    user_alice="alice-secret";
+};

--- a/examples/acl-creation-multiops/playbook.yml
+++ b/examples/acl-creation-multiops/playbook.yml
@@ -1,0 +1,98 @@
+---
+- name: Example | ACL creation
+  hosts: 127.0.0.1
+  roles:
+    - name: kafka_lib
+  post_tasks:
+    - name: "Create a single ACL with multiple operations"
+      kafka_acl:
+        name: 'my-topic'
+        api_version: "2.6.0"
+        acl_resource_type: 'topic'
+        acl_principal: 'User:producer-client'
+        acl_operation: 'write'
+        acl_permission: 'allow'
+        acl_pattern_type: 'literal'
+        bootstrap_servers: "localhost:9092"
+
+    - name: "Create a single ACL with multiple operations"
+      kafka_acl:
+        name: 'my-topic'
+        api_version: "2.6.0"
+        acl_resource_type: 'topic'
+        acl_principal: 'User:producer-client'
+        acl_operations:
+          - 'write'
+          - 'describe'
+          - 'create'
+        acl_permission: 'allow'
+        acl_pattern_type: 'literal'
+        bootstrap_servers: "localhost:9092"
+
+
+    - name: "Create multiple ACL with multiple operations"
+      kafka_acls:
+
+        acls:
+          - name: 'my-topic'
+            acl_resource_type: 'topic'
+            acl_principal: 'User:consumer-client'
+            acl_operations:
+              - 'describe'
+              - 'read'
+            acl_permission: 'allow'
+            acl_pattern_type: 'literal'
+
+          - name: 'my-consumer-group'
+            acl_resource_type: 'group'
+            acl_principal: 'User:consumer-client'
+            acl_operations:
+              - 'read'
+            acl_permission: 'allow'
+            acl_pattern_type: 'literal'
+
+        api_version: "2.6.0"
+        bootstrap_servers: "localhost:9092"
+
+    - name: "Get ACLs information"
+      kafka_info:
+        resource: "acl"
+        api_version: "2.6.0"
+        bootstrap_servers: "localhost:9092"
+      register: acls
+
+    - name: "Display results"
+      debug:
+        var: acls
+
+
+    - name: "Delete multiple ACL with multiple operations"
+      kafka_acls:
+
+        acls:
+          - name: 'my-topic'
+            acl_resource_type: 'topic'
+            acl_principal: 'User:producer-client'
+            acl_operations:
+              - 'write'
+            acl_permission: 'allow'
+            acl_pattern_type: 'literal'
+            state: 'absent'
+
+          # Delete ALL operations
+          - name: 'my-topic'
+            acl_principal: 'User:consumer-client'
+            state: 'absent'
+
+        bootstrap_servers: "localhost:9092"
+
+    - name: "Get ACLs information"
+      kafka_info:
+        resource: "acl"
+        api_version: "2.6.0"
+        bootstrap_servers: "localhost:9092"
+      register: acls
+
+    - name: "Display results"
+      debug:
+        var: acls

--- a/library/kafka_acl.py
+++ b/library/kafka_acl.py
@@ -15,7 +15,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.kafka_lib_acl import process_module_acl
 
 from ansible.module_utils.kafka_lib_commons import (
-    module_commons, module_acl_commons,
+    module_commons, module_acl_commons, module_acl_commons_validations,
     DOCUMENTATION_COMMON
 )
 
@@ -52,6 +52,7 @@ options:
   state:
     description:
       - 'state of the managed resource.'
+      - 'when state = present, one of acl_operation|acl_operations is required'
     default: present
     choices: [present, absent]
   acl_resource_type:
@@ -68,6 +69,13 @@ options:
   acl_operation:
     description:
       - 'the operation the ACL controls.'
+      - 'mutually exclusive with acl_operation'
+    choices: [all, alter, alter_configs, cluster_action, create, delete,
+                describe, describe_configs, idempotent_write, read, write]
+  acl_operations:
+    description:
+      - 'a list of operations the ACL controls.'
+      - 'mutually exclusive with acl_operation'
     choices: [all, alter, alter_configs, cluster_action, create, delete,
                 describe, describe_configs, idempotent_write, read, write]
   acl_pattern_type:
@@ -120,20 +128,15 @@ def main():
     """
     Module usage
     """
-
     spec = dict(
-        # resource name
-        name=dict(type='str', required=True),
-
-        state=dict(choices=['present', 'absent'], default='present'),
-
         **module_commons
     )
     spec.update(module_acl_commons)
 
     module = AnsibleModule(
         argument_spec=spec,
-        supports_check_mode=True
+        supports_check_mode=True,
+        **module_acl_commons_validations
     )
     process_module_acl(module)
 

--- a/library/kafka_acls.py
+++ b/library/kafka_acls.py
@@ -15,7 +15,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.kafka_lib_acl import process_module_acls
 
 from ansible.module_utils.kafka_lib_commons import (
-    module_commons, module_acl_commons,
+    module_commons, module_acl_commons, module_acl_commons_validations,
     DOCUMENTATION_COMMON
 )
 
@@ -94,14 +94,11 @@ def main():
     spec = dict(
         mark_others_as_absent=dict(type='bool', default=False),
         acls=dict(
-            type='list',
-            elements='dict',
-            required=True,
-            options=dict(
-                name=dict(type='str', required=True),
-                state=dict(choices=['present', 'absent'], default='present'),
-                **module_acl_commons
-            )
+          type='list',
+          elements='dict',
+          required=True,
+          options=module_acl_commons,
+          **module_acl_commons_validations
         ),
         **module_commons
     )

--- a/module_utils/kafka_acl.py
+++ b/module_utils/kafka_acl.py
@@ -23,6 +23,10 @@ class ACLOperation(IntEnum):
     ALTER_CONFIGS = 11,
     IDEMPOTENT_WRITE = 12
 
+    def __eq__(self, other):
+        return int(self) == int(other) or \
+            self is ACLOperation.ANY or other is ACLOperation.ANY
+
     @staticmethod
     def from_name(name):
         if not isinstance(name, str):
@@ -190,7 +194,7 @@ class ACLResource(object):
             return NotImplemented
         return (
             self.resource_type.value == other.resource_type.value and
-            self.operation.value == other.operation.value and
+            self.operation == other.operation and
             self.permission_type.value == other.permission_type.value and
             self.name == other.name and
             self.principal == other.principal and

--- a/module_utils/kafka_lib_commons.py
+++ b/module_utils/kafka_lib_commons.py
@@ -87,25 +87,71 @@ module_topic_commons = dict(
     options=dict(required=False, type='dict', default={}),
 )
 
+acl_operations_choices = [
+    'all',
+    'alter',
+    'alter_configs',
+    'cluster_action',
+    'create',
+    'delete',
+    'describe',
+    'describe_configs',
+    'idempotent_write',
+    'read',
+    'write'
+]
+
+module_acl_commons_validations = dict(
+    mutually_exclusive=[
+        ('acl_operation', 'acl_operations')
+    ],
+    required_if=[
+        ('state', 'present', ('acl_operation', 'acl_operations'), True)
+    ]
+)
+
 module_acl_commons = dict(
-    acl_resource_type=dict(choices=['topic', 'broker', 'cluster',
-                                    'delegation_token', 'group',
-                                    'transactional_id'],
-                           default='topic'),
+
+    name=dict(type='str', required=True),
+    state=dict(
+        choices=['present', 'absent'],
+        default='present'
+    ),
+    acl_resource_type=dict(
+        choices=[
+            'topic',
+            'broker',
+            'cluster',
+            'delegation_token',
+            'group',
+            'transactional_id'
+        ],
+        default='topic'
+    ),
 
     acl_principal=dict(type='str', required=False),
+    acl_operations=dict(
+        type='list',
+        elements='str',
+        choices=acl_operations_choices
+    ),
+    acl_operation=dict(
+        choices=acl_operations_choices,
+        required=False
+    ),
 
-    acl_operation=dict(choices=['all', 'alter', 'alter_configs',
-                                'cluster_action', 'create', 'delete',
-                                'describe', 'describe_configs',
-                                'idempotent_write', 'read', 'write'],
-                       required=False),
-    acl_pattern_type=dict(choice=['any', 'match', 'literal',
-                                  'prefixed'],
-                          required=False, default='literal'),
+    acl_pattern_type=dict(
+        choice=[
+            'any',
+            'match',
+            'literal',
+            'prefixed'
+        ],
+        required=False,
+        default='literal'
+    ),
 
     acl_permission=dict(choices=['allow', 'deny'], default='allow'),
-
     acl_host=dict(type='str', required=False, default="*"),
 )
 

--- a/module_utils/kafka_manager.py
+++ b/module_utils/kafka_manager.py
@@ -245,7 +245,7 @@ class KafkaManager:
 
     @staticmethod
     def _convert_create_acls_resource_request_v0(acl_resource):
-        if acl_resource.operation == ACLOperation.ANY:
+        if acl_resource.operation is ACLOperation.ANY:
             raise IllegalArgumentError("operation must not be ANY")
         if acl_resource.permission_type == ACLPermissionType.ANY:
             raise IllegalArgumentError("permission_type must not be ANY")
@@ -261,7 +261,7 @@ class KafkaManager:
 
     @staticmethod
     def _convert_create_acls_resource_request_v1(acl_resource):
-        if acl_resource.operation == ACLOperation.ANY:
+        if acl_resource.operation is ACLOperation.ANY:
             raise IllegalArgumentError("operation must not be ANY")
         if acl_resource.permission_type == ACLPermissionType.ANY:
             raise IllegalArgumentError("permission_type must not be ANY")

--- a/molecule/default/tests/ansible_utils.py
+++ b/molecule/default/tests/ansible_utils.py
@@ -54,6 +54,18 @@ acl_defaut_configuration = {
     'acl_pattern_type': 'literal'
 }
 
+acl_multi_ops_configuration = {
+    'acl_resource_type': 'topic',
+    'state': 'absent',
+    'acl_principal': 'User:common',
+    'acl_operations': [
+        'write',
+        'describe'
+    ],
+    'acl_permission': 'allow',
+    'acl_pattern_type': 'literal'
+}
+
 cg_defaut_configuration = {}
 
 quotas_default_configuration = {}

--- a/tests/module_utils/test_kafka_acls.py
+++ b/tests/module_utils/test_kafka_acls.py
@@ -1,0 +1,26 @@
+
+from module_utils.kafka_acl import ACLResourceType as rs
+from module_utils.kafka_acl import ACLOperation as op
+from module_utils.kafka_acl import (
+    ACLResource, ACLPermissionType, ACLPatternType
+)
+
+
+def test_acl_operations_equality():
+    assert op.ANY == op.WRITE
+    assert op.WRITE == op.WRITE
+    assert op.READ != op.WRITE
+
+
+def test_acl_resource_equality():
+    commons = {
+        'pattern_type': ACLPatternType.LITERAL,
+        'name': 'my-topic',
+        'principal': 'User:alice',
+        'host': '*'
+    }
+    r1 = ACLResource(rs.TOPIC, op.WRITE, ACLPermissionType.ALLOW, **commons)
+    r2 = ACLResource(rs.TOPIC, op.ANY, ACLPermissionType.ALLOW, **commons)
+
+    assert r1 == r2
+    assert r1 in [r2]


### PR DESCRIPTION
Fixes #70 
Fixes #124 

## Proposed Changes

 - Allow to specify multiple acl_operations 

```

 - name: "Create a single ACL with multiple operations"
      kafka_acl:
        name: 'my-topic'
        api_version: "2.6.0"
        acl_resource_type: 'topic'
        acl_principal: 'User:producer-client'
        acl_operations: 
          - 'write'
          - 'describe'
          - 'create'
        acl_permission: 'allow'
        acl_pattern_type: 'literal'
        bootstrap_servers: "localhost:9092"

- name: "Create multiple ACL with multiple operations"
      kafka_acls:

        acls:
          - name: 'my-topic'
            acl_resource_type: 'topic'
            acl_principal: 'User:consumer-client'
            acl_operations: 
              - 'describe'
              - 'read'
            acl_permission: 'allow'
            acl_pattern_type: 'literal'

          - name: 'my-consumer-group'
            acl_resource_type: 'group'
            acl_principal: 'User:consumer-client'
            acl_operations: 
              - 'read'
            acl_permission: 'allow'
            acl_pattern_type: 'literal'

        api_version: "2.6.0"
        bootstrap_servers: "localhost:9092"
```

- Allow to use state=absent without acl_operation/acl_operations 

```
    - name: "Delete any ACL of a given resource"
      kafka_acls:

        acls:
          - name: 'my-topic'
            acl_principal: 'User:consumer-client'
            state: 'absent'

        bootstrap_servers: "localhost:9092"
```