### PR TITLE
Bump testing libs and use Python 3.11

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: [2-slim, 3.5-slim, 3.6-slim, 3.7-slim, 3.8-slim, 3.9-slim, 3.10-slim]
+        python_version: [2-slim, 3.5-slim, 3.6-slim, 3.7-slim, 3.8-slim, 3.9-slim, 3.10-slim, 3.11-slim]
         group: [1, 2]
         scenario:
           - default
@@ -24,10 +24,10 @@ jobs:
         run: |
           set -e
           docker info
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           pip install -r test-requirements.txt

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -640,9 +640,10 @@ This library is tested with the following versions of Python:
 * Python 3.8
 * Python 3.9
 * Python 3.10
+* Python 3.11
 
 ## Ansible compatibility
-To date, this library is compatible with every versions of Ansible 2.X (`ansible`/`ansible-core` 2.X or `ansible` 4.X).
+To date, this library is compatible with all known versions of Ansible 2.X (`ansible`/`ansible-core` 2.X).
 
 ## Tests
 This library is tested using [Molecule](https://github.com/ansible/molecule). In order to avoid code duplication, tests are defined in the `default` scenario.

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -6,7 +6,7 @@ FROM {{ item.registry.url }}/{{ item.image }}
 FROM {{ item.image }}
 {% endif %}
 
-RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python sudo bash ca-certificates iproute2 && apt-get clean; \
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python2 sudo bash ca-certificates iproute2 && apt-get clean; \
     elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash iproute2 && dnf clean all; \
     elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash iproute2 && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
     elif [ $(command -v zypper) ]; then zypper refresh && zypper update -y && zypper install -y python sudo bash python-xml iproute2 && zypper clean -a; \

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,4 +1,5 @@
 ---
+role_name_check: 1
 dependency:
   name: galaxy
 driver:
@@ -331,5 +332,3 @@ verifier:
     group: "${PYTEST_SPLIT_GROUP:-1}"
     splits: "${PYTEST_SPLIT_SPLITS:-1}"
     timeout: "${PYTEST_TIMEOUT_S:-600}"
-  lint:
-    name: flake8

--- a/molecule/scram-kafka-270/Dockerfile.j2
+++ b/molecule/scram-kafka-270/Dockerfile.j2
@@ -6,7 +6,7 @@ FROM {{ item.registry.url }}/{{ item.image }}
 FROM {{ item.image }}
 {% endif %}
 
-RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python sudo bash ca-certificates iproute2 && apt-get clean; \
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python2 sudo bash ca-certificates iproute2 && apt-get clean; \
     elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash iproute2 && dnf clean all; \
     elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash iproute2 && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
     elif [ $(command -v zypper) ]; then zypper refresh && zypper update -y && zypper install -y python sudo bash python-xml iproute2 && zypper clean -a; \

--- a/molecule/scram-kafka-270/molecule.yml
+++ b/molecule/scram-kafka-270/molecule.yml
@@ -1,4 +1,5 @@
 ---
+role_name_check: 1
 dependency:
   name: galaxy
 driver:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,8 +1,8 @@
-ansible==2.10.7
-ansible-lint==4.3.7
+ansible==7.3.0
+ansible-lint==6.14.2
 funcsigs
-molecule==3.2.2
-molecule-docker==0.3.3
+molecule==4.0.4
+molecule-plugins[docker]==23.0.0
 pytest-testinfra==6.1.0
 pytest-xdist==2.2.1
 pytest-instafail==0.4.2


### PR DESCRIPTION
## Proposed Changes
  - add tests for Python 3.11
  - use Python 3.11 for tooling instead of Python 3.10
  - fix `apt install python` -> `apt install python2` in `Dockerfile.j2`
  - bump ansible to 7.4.0
  - bump ansible-lint to 6.14.2
  - bump molecule to 4.0.4
  - replace molecule-docker with molecule-plugins[docker]
  - update `README.md`