### PR TITLE
Publish to Ansible Galaxy as part of the release

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -22,8 +22,14 @@ jobs:
       - name: Build ansible collection package
         run: |
           ./build-ansible-collection.sh
-      - uses: softprops/action-gh-release@v1
+      - name: Publish to GH releases
+        uses: softprops/action-gh-release@v1
         with:
           files: "build/StephenSorriaux-ansible_kafka_admin-*"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish to Ansible galaxy
+        run: |
+          ./publish-ansible-collection.sh
+        env:
+          API_KEY: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}

--- a/publish-ansible-collection.sh
+++ b/publish-ansible-collection.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+VERSION=$(git describe --abbrev=0 --tags)
+NAMESPACE=StephenSorriaux
+NAME=ansible_kafka_admin
+
+cd build
+
+ansible-galaxy collection publish ${NAMESPACE}-${NAME}-${VERSION}.tar.gz --api-key=${API_KEY}


### PR DESCRIPTION
Fixes #142 

## Proposed Changes
  - Add a `publish-ansible-collection.sh` script
  - Use it when performing a release

Will publish under the name `ansible_kafka_admin`, so will probably need to remove the very old one at some point to avoid the useless duplicate.