### PR TITLE
Fix topics `check_mode` and test for `changed` result

### DIFF
--- a/module_utils/kafka_lib_topic.py
+++ b/module_utils/kafka_lib_topic.py
@@ -61,17 +61,23 @@ def process_module_topics(module, params=None):
                 topic['name'] in current_topics)
         ]
         if len(topics_to_maybe_update) > 0:
-            if not module.check_mode:
+            if module.check_mode:
+                # just discover topics that will change
+                topics_changed, warn = manager.get_topics_to_update(
+                    topics_to_maybe_update
+                )
+            else:
+                # perform the changes
                 topics_changed, warn = manager.ensure_topics(
                     topics_to_maybe_update
                 )
-                changed = len(topics_changed) > 0
-                if changed:
-                    msg += ''.join(['topic %s successfully updated. ' %
-                                    topic for topic in topics_changed])
-                    changes.update({
-                        'topic_updated': topics_changed
-                    })
+            changed = len(topics_changed) > 0
+            if changed:
+                msg += ''.join(['topic %s successfully updated. ' %
+                                topic for topic in topics_changed])
+                changes.update({
+                    'topic_updated': topics_changed
+                })
 
         topics_to_delete = [
             topic for topic in topics

--- a/molecule/default/tests/test_acl_default.py
+++ b/molecule/default/tests/test_acl_default.py
@@ -113,6 +113,7 @@ def test_check_mode(host, acl_configuration):
     Check if can check mode do nothing
     """
     # Given
+    results = []
     test_acl_configuration = acl_configuration.copy()
     test_acl_configuration.update({
         'name': get_acl_name(),
@@ -129,7 +130,7 @@ def test_check_mode(host, acl_configuration):
     check_acl_configuration.update({
         'state': 'absent'
     })
-    ensure_kafka_acl(
+    results += ensure_kafka_acl(
         host,
         check_acl_configuration,
         check=True
@@ -139,13 +140,15 @@ def test_check_mode(host, acl_configuration):
         'state': 'present',
         'name': "test_" + str(time.time())
     })
-    ensure_kafka_acl(
+    results += ensure_kafka_acl(
         host,
         check_acl_configuration,
         check=True
     )
     time.sleep(0.3)
     # Then
+    for result in results:
+        assert result['changed']
     for host, host_vars in kafka_hosts.items():
         kfk_sasl_addr = "%s:9094" % \
             host_vars['ansible_eth0']['ipv4']['address']['__ansible_unsafe']

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -383,6 +383,7 @@ def test_check_mode(host):
     Check if can check mode do nothing
     """
     # Given
+    results = []
     topic_name = get_topic_name()
     ensure_topic(
         host,
@@ -406,7 +407,7 @@ def test_check_mode(host):
     test_topic_configuration.update({
         'state': 'absent'
     })
-    ensure_topic(
+    results += ensure_topic(
         host,
         test_topic_configuration,
         topic_name,
@@ -421,7 +422,7 @@ def test_check_mode(host):
             'retention.ms': 1000
         }
     })
-    ensure_topic(
+    results += ensure_topic(
         host,
         test_topic_configuration,
         topic_name,
@@ -429,7 +430,7 @@ def test_check_mode(host):
     )
     time.sleep(0.3)
     new_topic_name = get_topic_name()
-    ensure_topic(
+    results += ensure_topic(
         host,
         test_topic_configuration,
         new_topic_name,
@@ -440,7 +441,7 @@ def test_check_mode(host):
     check_acl_configuration.update({
         'state': 'absent'
     })
-    ensure_acl(
+    results += ensure_acl(
         host,
         check_acl_configuration,
         check=True
@@ -450,13 +451,15 @@ def test_check_mode(host):
         'state': 'present',
         'name': get_topic_name()
     })
-    ensure_acl(
+    results += ensure_acl(
         host,
         check_acl_configuration,
         check=True
     )
     time.sleep(0.3)
     # Then
+    for result in results:
+        assert result['changed']
     expected_topic_configuration = topic_defaut_configuration.copy()
     for kafka_host, host_vars in kafka_hosts.items():
         kfk_addr = "%s:9092" % \

--- a/molecule/default/tests/test_topic_default.py
+++ b/molecule/default/tests/test_topic_default.py
@@ -499,9 +499,10 @@ def test_delete_topic(host):
 
 def test_check_mode(host):
     """
-    Check if can check mode do nothing
+    Check if check mode do nothing while showing the tasks as "changed"
     """
     # Given
+    results = []
     topic_name = get_topic_name()
     ensure_kafka_topic(
         host,
@@ -514,7 +515,7 @@ def test_check_mode(host):
     test_topic_configuration.update({
         'state': 'absent'
     })
-    ensure_kafka_topic_with_zk(
+    results += ensure_kafka_topic_with_zk(
         host,
         test_topic_configuration,
         topic_name,
@@ -529,7 +530,7 @@ def test_check_mode(host):
             'retention.ms': 1000
         }
     })
-    ensure_kafka_topic_with_zk(
+    results += ensure_kafka_topic_with_zk(
         host,
         test_topic_configuration,
         topic_name,
@@ -537,7 +538,7 @@ def test_check_mode(host):
     )
     time.sleep(0.3)
     new_topic_name = get_topic_name()
-    ensure_kafka_topic_with_zk(
+    results += ensure_kafka_topic_with_zk(
         host,
         test_topic_configuration,
         new_topic_name,
@@ -545,6 +546,8 @@ def test_check_mode(host):
     )
     time.sleep(0.3)
     # Then
+    for result in results:
+        assert result['changed']
     expected_topic_configuration = topic_defaut_configuration.copy()
     for host, host_vars in kafka_hosts.items():
         kfk_addr = "%s:9092" % \


### PR DESCRIPTION
Fixes #137 

## Proposed Changes
  - add `get_topics_to_update()` method in `KafkaManager` that lists all topics that would be updated
  - use `get_topics_to_update()` if `check_mode=True` so that the status of the task is correct
  - update tests making use of `check=True` to check that the `changed` result is `True`
