### PR TITLE
Fix namespace for Ansible Galaxy

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -19,15 +19,18 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install -r test-requirements.txt
-      - name: Build ansible collection package
+      - name: Build ansible collection package with StephenSorriaux namespace
         run: |
-          ./build-ansible-collection.sh
+          ./build-ansible-collection.sh StephenSorriaux
       - name: Publish to GH releases
         uses: softprops/action-gh-release@v1
         with:
           files: "build/StephenSorriaux-ansible_kafka_admin-*"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build ansible collection package with stephensorriaux namespace
+        run: |
+          ./build-ansible-collection.sh stephensorriaux
       - name: Publish to Ansible galaxy
         run: |
           ./publish-ansible-collection.sh

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ collections:
 - name: https://github.com/StephenSorriaux/ansible-kafka-admin/releases/download/VERSION/StephenSorriaux-ansible_kafka_admin-VERSION.tar.gz
 ```
 Then you can use it adding `StephenSorriaux.ansible_kafka_admin.` namespace prefix before any of defined modules.
+### Using Ansible Galaxy
+The lib is available under [https://galaxy.ansible.com/stephensorriaux/ansible_kafka_admin](https://galaxy.ansible.com/stephensorriaux/ansible_kafka_admin).
 ## Usage
 ### Creating, updating, deleting topics and ACLs
 **Note**:

--- a/build-ansible-collection.sh
+++ b/build-ansible-collection.sh
@@ -2,7 +2,7 @@
 
 VERSION=$(git describe --abbrev=0 --tags)
 CURRENT_MODULES=$(find module_utils -type f -iname "*.py" -execdir basename {} .py ';')
-NAMESPACE=StephenSorriaux
+NAMESPACE=$1
 NAME=ansible_kafka_admin
 
 mkdir -p build/plugins/{modules,module_utils}

--- a/publish-ansible-collection.sh
+++ b/publish-ansible-collection.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 VERSION=$(git describe --abbrev=0 --tags)
-NAMESPACE=StephenSorriaux
+NAMESPACE=stephensorriaux
 NAME=ansible_kafka_admin
 
 cd build


### PR DESCRIPTION
## Proposed Changes

  - add `ansible-galaxy collection build` step with `stephensorriaux` namespace (because of https://galaxy.ansible.com/docs/contributing/namespaces.html#namespace-limitations)
  - publish to Ansible Galaxy using `stephensorriaux` namespace (but keep `StephenSorriaux` namespace for GH release, maybe need to deprecate it?)
  - update `README.md`
