### PR TITLE
Don't perform upload to Ansible Galaxy

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -28,11 +28,5 @@ jobs:
           files: "build/StephenSorriaux-ansible_kafka_admin-*"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build ansible collection package with stephensorriaux namespace
-        run: |
-          ./build-ansible-collection.sh stephensorriaux
-      - name: Publish to Ansible galaxy
-        run: |
-          ./publish-ansible-collection.sh
         env:
           API_KEY: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ collections:
 ```
 Then you can use it adding `StephenSorriaux.ansible_kafka_admin.` namespace prefix before any of defined modules.
 ### Using Ansible Galaxy
-The lib is available under [https://galaxy.ansible.com/stephensorriaux/ansible_kafka_admin](https://galaxy.ansible.com/stephensorriaux/ansible_kafka_admin).
+The lib is available under [https://galaxy.ansible.com/StephenSorriaux/kafka-admin](https://galaxy.ansible.com/StephenSorriaux/kafka-admin).
 ## Usage
 ### Creating, updating, deleting topics and ACLs
 **Note**:


### PR DESCRIPTION
## Proposed Changes

  - do not perform upload to Ansible Galaxy for now because the `stephensorriaux` namespace does not exist (see https://github.com/StephenSorriaux/ansible-kafka-admin/actions/runs/4479355989/jobs/7873207131), while `StephenSorriaux` does exists bu the API says it is now invalid without any means for me to change it. Moreover, it seems like a new version of Ansible Galaxy is being developed (https://github.com/ansible/galaxy/issues/3086) so I will just wait for it to automatize the upload
  - in the meantime, I will just manually sync the https://galaxy.ansible.com/StephenSorriaux/kafka-admin by clicking the button when a new release of the lib is there, since this seems to just work
