### PR TITLE
fix bug with change flag

### DIFF
--- a/module_utils/kafka_lib_topic.py
+++ b/module_utils/kafka_lib_topic.py
@@ -71,8 +71,8 @@ def process_module_topics(module, params=None):
                 topics_changed, warn = manager.ensure_topics(
                     topics_to_maybe_update
                 )
-            changed = len(topics_changed) > 0
-            if changed:
+            changed = changed or len(topics_changed) > 0
+            if len(topics_changed) > 0:
                 msg += ''.join(['topic %s successfully updated. ' %
                                 topic for topic in topics_changed])
                 changes.update({


### PR DESCRIPTION
Fixes #

## Proposed Changes
Currently change flag in kafka_lib_topic may be set to False even though it was already set to True
To fix this, let the change flag remain true by:
`changed = changed or len(topics_changed) > 0`
  -
  -
  -
