### PR TITLE
Pin `kafka-python` version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-kafka-python>=2.0.0,<2.1.0
+kafka-python==2.0.2
 kazoo==2.6.1
 pure-sasl==0.5.1
 setuptools; python_version >= '3.12'


### PR DESCRIPTION
## Proposed Changes

  - Pin `kafka-python` to 2.0.2 version since later versions (2.0.3, 2.0.4) seems to have breaking changes
