### PR TITLE
Fix mark other as absent for kafka_topics

### DIFF
--- a/library/kafka_topics.py
+++ b/library/kafka_topics.py
@@ -52,6 +52,11 @@ options:
     description:
       - make non listed topics as absent, thus triggering the deletion
       - of topics absent from the `topics` listing
+  ignore_topics:
+    description:
+      - list of topics to disable management for.
+      - Topics in this list can be managed explicitly with state.
+    default: [__consumer_offsets, __transaction_state, _schemas]
   zookeeper:
     description:
       - 'the zookeeper connection.'
@@ -153,6 +158,15 @@ def main():
     """
     spec = dict(
         mark_others_as_absent=dict(type='bool', default=False),
+        ignore_topics=dict(
+          type='list',
+          elements='str',
+          default=[
+            '__consumer_offsets',
+            '__transaction_state',
+            '_schemas'
+          ]
+        ),
         topics=dict(
             type='list',
             elements='dict',

--- a/module_utils/kafka_lib_topic.py
+++ b/module_utils/kafka_lib_topic.py
@@ -17,6 +17,7 @@ def process_module_topics(module, params=None):
 
     topics = params['topics']
     mark_others_as_absent = params.get('mark_others_as_absent', False)
+    ignore_topics = set(params.get('ignore_topics', []))
 
     # Check for duplicated topics
     duplicated_topics = [topic for topic, count in collections.Counter(
@@ -86,7 +87,12 @@ def process_module_topics(module, params=None):
         # Cleanup existing if necessary
         if mark_others_as_absent:
             defined_topics = [topic['name'] for topic in topics]
-            for existing_topic in set(current_topics) - set(defined_topics):
+            # Remove ignored topics from management.
+            for existing_topic in (
+                    set(current_topics) -
+                    set(ignore_topics) -
+                    set(defined_topics)
+                  ):
                 topics_to_delete.append({
                     'name': existing_topic,
                     'state': 'absent'


### PR DESCRIPTION
Fixes #200

## Proposed Changes

  - add parameter to specify the list of excluded topics for implicit topic management
